### PR TITLE
Add detailed clinical suite world and analysis tooling

### DIFF
--- a/src/analyze_world.ts
+++ b/src/analyze_world.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env bun
+import { readFile } from "node:fs/promises";
+
+import { runSimulation } from "./sim";
+import { WorldFile, Event } from "./contracts";
+
+type DiseaseConfig = {
+  label: string;
+  codes: string[];
+  labIds: string[];
+  medications: string[];
+  encounterKinds?: Array<"PCP" | "ED" | "Inpatient" | "Specialty">;
+  extra?: (patient: SimPatientView, events: Event[]) => Record<string, number | Record<string, number>>;
+};
+
+type SimPatientView = {
+  id: string;
+  attrs: Record<string, number | string | boolean>;
+  events: Event[];
+};
+
+type SummaryRow = {
+  diagnosed: number;
+  diagnosisRate: number;
+  meanDiagnosisAge: number | null;
+  labs: Record<string, { mean: number; count: number }>;
+  medicationCoverage: Record<string, number>;
+  encounterRate?: Record<string, number>;
+  extra?: Record<string, number | Record<string, number>>;
+};
+
+const diseases: Record<string, DiseaseConfig> = {
+  diabetes: {
+    label: "Type 2 Diabetes Mellitus",
+    codes: ["E11.9"],
+    labIds: ["A1C", "FPG"],
+    medications: ["Metformin", "Semaglutide", "Lisinopril"],
+    encounterKinds: ["Specialty"]
+  },
+  cad: {
+    label: "Coronary Artery Disease",
+    codes: ["I25.10"],
+    labIds: ["LIPID_LDL", "LIPID_HDL", "LIPID_TG"],
+    medications: ["Atorvastatin", "Simvastatin", "Aspirin", "Rosuvastatin", "Ezetimibe"],
+    encounterKinds: ["ED", "Inpatient", "Specialty"],
+    extra: (_patient, events) => {
+      const interventions = events.filter((e) => e.type === "procedure" && (e.payload.name.includes("angi") || e.payload.name.includes("coronary")));
+      return { revascularizationEvents: interventions.length };
+    }
+  },
+  copd: {
+    label: "Chronic Obstructive Pulmonary Disease",
+    codes: ["J44.9"],
+    labIds: ["SPIRO_FEV1"],
+    medications: ["Tiotropium inhaler", "Albuterol inhaler", "Budesonide-formoterol", "Home oxygen"],
+    encounterKinds: ["ED", "Inpatient"]
+  },
+  ckd: {
+    label: "Chronic Kidney Disease",
+    codes: ["N18.3", "N18.4", "N18.5"],
+    labIds: ["LAB_EGFR", "LAB_CREAT", "LAB_UACR"],
+    medications: ["Lisinopril", "Empagliflozin", "Erythropoietin"],
+    encounterKinds: ["Specialty"],
+    extra: (patient) => {
+      const egfr = typeof patient.attrs.EGFR === "number" ? (patient.attrs.EGFR as number) : null;
+      const stage = egfr == null ? "unknown" : egfr >= 60 ? "2" : egfr >= 45 ? "3a" : egfr >= 30 ? "3b" : egfr >= 15 ? "4" : "5";
+      return { stageDistribution: { [stage]: 1 } };
+    }
+  },
+  mdd: {
+    label: "Major Depressive Disorder",
+    codes: ["F33.1"],
+    labIds: ["PHQ9"],
+    medications: ["Sertraline", "Bupropion"],
+    encounterKinds: ["Specialty"],
+    extra: (_patient, events) => {
+      const therapy = events.filter((e) => e.type === "procedure" && e.payload.name.includes("Psychotherapy"));
+      return { psychotherapySessions: therapy.length };
+    }
+  }
+};
+
+function mean(values: number[]): number | null {
+  if (!values.length) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function summarizeDisease(patients: SimPatientView[], cfg: DiseaseConfig, total: number): SummaryRow {
+  const diagnosedPatients = patients.filter((p) =>
+    p.events.some((e) => e.type === "diagnosis" && cfg.codes.includes(e.payload.code))
+  );
+  const diagCount = diagnosedPatients.length;
+  const diagnosisAges: number[] = [];
+  const labStats: Record<string, { mean: number; count: number }> = {};
+  const medCoverage: Record<string, number> = {};
+  const encounterRate: Record<string, number> = {};
+  const extraSummaries: Record<string, number | Record<string, number>> = {};
+
+  for (const med of cfg.medications) {
+    medCoverage[med] = 0;
+  }
+  if (cfg.encounterKinds) {
+    for (const kind of cfg.encounterKinds) encounterRate[kind] = 0;
+  }
+
+  for (const patient of diagnosedPatients) {
+    const ageBase = typeof patient.attrs.AGE_YEARS === "number" ? (patient.attrs.AGE_YEARS as number) : 0;
+    const diagEvent = patient.events.find((e) => e.type === "diagnosis" && cfg.codes.includes(e.payload.code));
+    if (diagEvent) diagnosisAges.push(ageBase + diagEvent.t);
+    const followYears = Math.max(1, patient.events.length ? patient.events[patient.events.length - 1].t : 0);
+
+    const lastLabs: Record<string, number> = {};
+    for (const event of patient.events) {
+      if (event.type === "lab" && cfg.labIds.includes(event.payload.id)) {
+        lastLabs[event.payload.id] = event.payload.value;
+      }
+    }
+    for (const [labId, value] of Object.entries(lastLabs)) {
+      if (!labStats[labId]) labStats[labId] = { mean: 0, count: 0 };
+      labStats[labId].mean += value;
+      labStats[labId].count += 1;
+    }
+
+    const meds = new Set(
+      patient.events.filter((e) => e.type === "medication" && cfg.medications.includes(e.payload.drug)).map((e) => e.payload.drug)
+    );
+    for (const med of meds) {
+      medCoverage[med] = (medCoverage[med] ?? 0) + 1;
+    }
+
+    if (cfg.encounterKinds) {
+      const counts: Record<string, number> = {};
+      for (const kind of cfg.encounterKinds) counts[kind] = 0;
+      for (const event of patient.events) {
+        if (event.type === "encounter" && cfg.encounterKinds.includes(event.payload.kind)) {
+          counts[event.payload.kind] += 1;
+        }
+      }
+      for (const [kind, value] of Object.entries(counts)) {
+        encounterRate[kind] = (encounterRate[kind] ?? 0) + value / followYears;
+      }
+    }
+
+    if (cfg.extra) {
+      const extra = cfg.extra(patient, patient.events);
+      for (const [key, value] of Object.entries(extra)) {
+        const existing = extraSummaries[key];
+        if (typeof value === "number") {
+          extraSummaries[key] = (typeof existing === "number" ? (existing as number) : 0) + value;
+        } else {
+          const current = typeof existing === "object" && existing != null ? (existing as Record<string, number>) : {};
+          const next = extraSummaries as Record<string, Record<string, number>>;
+          const incoming = value as Record<string, number>;
+          const merged: Record<string, number> = { ...current };
+          for (const [k, v] of Object.entries(incoming)) {
+            merged[k] = (merged[k] ?? 0) + v;
+          }
+          next[key] = merged;
+        }
+      }
+    }
+  }
+
+  const summary: SummaryRow = {
+    diagnosed: diagCount,
+    diagnosisRate: total ? diagCount / total : 0,
+    meanDiagnosisAge: mean(diagnosisAges),
+    labs: {},
+    medicationCoverage: {},
+    encounterRate: cfg.encounterKinds ? {} : undefined,
+    extra: Object.keys(extraSummaries).length ? extraSummaries : undefined
+  };
+
+  for (const [labId, stat] of Object.entries(labStats)) {
+    summary.labs[labId] = {
+      mean: stat.count ? stat.mean / stat.count : 0,
+      count: stat.count
+    };
+  }
+
+  for (const [med, count] of Object.entries(medCoverage)) {
+    summary.medicationCoverage[med] = diagCount ? count / diagCount : 0;
+  }
+
+  if (summary.encounterRate) {
+    for (const [kind, count] of Object.entries(encounterRate)) {
+      summary.encounterRate[kind] = diagCount ? count / diagCount : 0;
+    }
+  }
+
+  if (summary.extra) {
+    for (const [key, value] of Object.entries(summary.extra)) {
+      if (typeof value === "number") {
+        summary.extra[key] = diagCount ? Number(value / diagCount) : 0;
+      } else {
+        const record = value as Record<string, number>;
+        const normalized: Record<string, number> = {};
+        for (const [stage, count] of Object.entries(record)) {
+          normalized[stage] = diagCount ? count / diagCount : 0;
+        }
+        summary.extra[key] = normalized;
+      }
+    }
+  }
+
+  return summary;
+}
+
+async function main() {
+  const args = new Map<string, string>();
+  for (let i = 2; i < Bun.argv.length; i++) {
+    const token = Bun.argv[i];
+    if (token.startsWith("--")) {
+      const key = token.slice(2);
+      const next = Bun.argv[i + 1];
+      if (next && !next.startsWith("--")) {
+        args.set(key, next);
+        i++;
+      } else {
+        args.set(key, "true");
+      }
+    }
+  }
+
+  const worldPath = args.get("world") ?? "worlds/clinical_suite/world.json";
+  const n = Number(args.get("n") ?? 200);
+  const worldData = await readFile(worldPath, "utf-8");
+  const world = JSON.parse(worldData) as WorldFile;
+
+  const patientsRaw = await runSimulation({ n, world });
+  const patients: SimPatientView[] = patientsRaw.map((p: any) => ({ id: p.id, attrs: p.attrs, events: p.events }));
+  const totalEvents = patients.reduce((sum, p) => sum + p.events.length, 0);
+  const encounterCounts = patients.map((p) => p.events.filter((e) => e.type === "encounter").length);
+
+  const diseaseSummaries: Record<string, SummaryRow> = {};
+  for (const [key, cfg] of Object.entries(diseases)) {
+    diseaseSummaries[key] = summarizeDisease(patients, cfg, patients.length);
+  }
+
+  const output = {
+    patients: patients.length,
+    avgEventsPerPatient: totalEvents / Math.max(1, patients.length),
+    avgEncounterPerPatient: encounterCounts.reduce((a, b) => a + b, 0) / Math.max(1, encounterCounts.length),
+    diseaseSummaries
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+await main();

--- a/worlds/clinical_suite/attribute_catalog.json
+++ b/worlds/clinical_suite/attribute_catalog.json
@@ -1,0 +1,37 @@
+{
+  "catalog": [
+    { "key": "AGE_YEARS", "type": "number", "durability": "intrinsic", "limits": { "min": 0, "max": 120 }, "description": "Age in years at simulation start", "category": "Demographics" },
+    { "key": "SEX_AT_BIRTH", "type": "string", "durability": "intrinsic", "description": "Sex assigned at birth", "category": "Demographics" },
+    { "key": "RACE", "type": "string", "durability": "intrinsic", "description": "Self-identified race", "category": "Demographics" },
+    { "key": "ETHNICITY", "type": "string", "durability": "intrinsic", "description": "Ethnicity per OMB standards", "category": "Demographics" },
+    { "key": "HOUSEHOLD_INCOME", "type": "number", "durability": "semi_durable", "limits": { "min": 0, "max": 250000 }, "description": "Estimated annual household income", "category": "Demographics" },
+    { "key": "HOUSEHOLD_SIZE", "type": "number", "durability": "semi_durable", "limits": { "min": 1, "max": 10 }, "description": "Number of household members", "category": "Demographics" },
+    { "key": "EDUCATION_LEVEL", "type": "string", "durability": "semi_durable", "description": "Highest completed education", "category": "Demographics" },
+    { "key": "INSURANCE_TYPE", "type": "string", "durability": "semi_durable", "description": "Primary health insurance coverage", "category": "Demographics" },
+    { "key": "FAMILY_HISTORY_DIABETES", "type": "boolean", "durability": "intrinsic", "description": "Family history of type 2 diabetes", "category": "Demographics" },
+    { "key": "FAMILY_HISTORY_CAD", "type": "boolean", "durability": "intrinsic", "description": "Family history of coronary artery disease", "category": "Demographics" },
+
+    { "key": "SMOKING_STATUS", "type": "string", "durability": "semi_durable", "description": "Smoking status (never/former/current)", "category": "Lifestyle" },
+    { "key": "SMOKING_PACK_YEARS", "type": "number", "durability": "semi_durable", "limits": { "min": 0, "max": 120 }, "description": "Cumulative pack-year exposure", "category": "Lifestyle" },
+    { "key": "ALCOHOL_USE_LEVEL", "type": "string", "durability": "semi_durable", "description": "Baseline alcohol consumption level", "category": "Lifestyle" },
+    { "key": "PHYSICAL_ACTIVITY_LEVEL", "type": "number", "durability": "semi_durable", "limits": { "min": 0, "max": 10 }, "description": "Weekly physical activity score", "category": "Lifestyle" },
+    { "key": "DIET_QUALITY_SCORE", "type": "number", "durability": "semi_durable", "limits": { "min": 0, "max": 100 }, "description": "Composite diet quality score", "category": "Lifestyle" },
+    { "key": "SLEEP_HOURS", "type": "number", "durability": "semi_durable", "limits": { "min": 3, "max": 12 }, "description": "Average nightly sleep duration", "category": "Lifestyle" },
+    { "key": "OCCUPATIONAL_EXPOSURE_DUST", "type": "boolean", "durability": "semi_durable", "description": "Occupational exposure to dust or fumes", "category": "Lifestyle" },
+    { "key": "MENTAL_HEALTH_SUPPORT", "type": "string", "durability": "semi_durable", "description": "Baseline access to supportive counseling", "category": "Lifestyle" },
+
+    { "key": "BMI", "type": "number", "durability": "semi_durable", "limits": { "min": 15, "max": 60 }, "description": "Body mass index", "category": "Clinical Baseline" },
+    { "key": "SYSTOLIC_BP", "type": "number", "durability": "semi_durable", "limits": { "min": 90, "max": 220 }, "description": "Systolic blood pressure (mmHg)", "category": "Clinical Baseline" },
+    { "key": "DIASTOLIC_BP", "type": "number", "durability": "semi_durable", "limits": { "min": 50, "max": 140 }, "description": "Diastolic blood pressure (mmHg)", "category": "Clinical Baseline" },
+    { "key": "LDL_CHOLESTEROL", "type": "number", "durability": "semi_durable", "limits": { "min": 40, "max": 260 }, "description": "Low-density lipoprotein cholesterol", "category": "Clinical Baseline" },
+    { "key": "HDL_CHOLESTEROL", "type": "number", "durability": "semi_durable", "limits": { "min": 20, "max": 120 }, "description": "High-density lipoprotein cholesterol", "category": "Clinical Baseline" },
+    { "key": "TRIGLYCERIDES", "type": "number", "durability": "semi_durable", "limits": { "min": 40, "max": 600 }, "description": "Triglyceride level (mg/dL)", "category": "Clinical Baseline" },
+    { "key": "FASTING_GLUCOSE", "type": "number", "durability": "semi_durable", "limits": { "min": 60, "max": 350 }, "description": "Fasting plasma glucose (mg/dL)", "category": "Clinical Baseline" },
+    { "key": "HBA1C", "type": "number", "durability": "semi_durable", "limits": { "min": 4.5, "max": 14 }, "description": "Hemoglobin A1c (%)", "category": "Clinical Baseline" },
+    { "key": "EGFR", "type": "number", "durability": "stateful", "limits": { "min": 5, "max": 140 }, "description": "Estimated glomerular filtration rate (mL/min/1.73m^2)", "category": "Clinical Baseline" },
+    { "key": "SERUM_CREATININE", "type": "number", "durability": "semi_durable", "limits": { "min": 0.4, "max": 8 }, "description": "Serum creatinine (mg/dL)", "category": "Clinical Baseline" },
+    { "key": "URINE_ALBUMIN", "type": "number", "durability": "semi_durable", "limits": { "min": 0, "max": 800 }, "description": "Urine albumin-to-creatinine ratio (mg/g)", "category": "Clinical Baseline" },
+    { "key": "RESPIRATORY_CAPACITY", "type": "number", "durability": "stateful", "limits": { "min": 30, "max": 120 }, "description": "FEV1 percent predicted", "category": "Clinical Baseline" },
+    { "key": "PHQ9_SCORE", "type": "number", "durability": "semi_durable", "limits": { "min": 0, "max": 27 }, "description": "PHQ-9 screening score", "category": "Clinical Baseline" }
+  ]
+}

--- a/worlds/clinical_suite/attributes/clinical_baseline.ts
+++ b/worlds/clinical_suite/attributes/clinical_baseline.ts
@@ -1,0 +1,245 @@
+import type { AttributeGroupModule } from "../../src/contracts";
+
+type RNG = () => number;
+
+function createRng(seed: number): RNG {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 22695477 + 1) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+const module: AttributeGroupModule = {
+  id: "ClinicalBaseline",
+  category: "Clinical Baseline",
+  summary: "Baseline vitals and laboratory markers with gentle longitudinal drift in response to lifestyle and disease signals.",
+  generate(seed: number, birthYear: number) {
+    const rng = createRng(seed ^ (birthYear * 97));
+
+    const metabolicFactor = rng();
+    const cardioFactor = rng();
+    const renalFactor = rng();
+    const respiratoryFactor = rng();
+    const moodFactor = rng();
+
+    const bmi = Number((22.5 + metabolicFactor * 12 + rng() * 1.5).toFixed(1));
+    const systolic = Math.round(108 + cardioFactor * 35 + metabolicFactor * 4);
+    const diastolic = Math.round(68 + cardioFactor * 18);
+    const ldl = Math.round(95 + cardioFactor * 55 - rng() * 10);
+    const hdl = Math.round(38 + (1 - metabolicFactor) * 18 + rng() * 5);
+    const triglycerides = Math.round(110 + metabolicFactor * 120 + rng() * 20);
+    const fastingGlucose = Math.round(88 + metabolicFactor * 45 + rng() * 8);
+    const hba1c = Number((5.1 + metabolicFactor * 1.9 + rng() * 0.2).toFixed(1));
+    const egfr = Number((70 + (1 - renalFactor) * 45).toFixed(1));
+    const creatinine = Number((0.7 + renalFactor * 1.2).toFixed(2));
+    const urineAlbumin = Number((12 + renalFactor * 40 + metabolicFactor * 10).toFixed(1));
+    const respiratoryCapacity = Math.round(78 + (1 - respiratoryFactor) * 18);
+    const baselinePhq9 = Math.round(2 + moodFactor * 10 + rng() * 3);
+
+    return {
+      attributes: {
+        BMI: {
+          value: bmi,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 15, max: 60 },
+          description: "Body mass index at baseline"
+        },
+        SYSTOLIC_BP: {
+          value: systolic,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 90, max: 220 },
+          description: "Systolic blood pressure (mmHg)"
+        },
+        DIASTOLIC_BP: {
+          value: diastolic,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 50, max: 140 },
+          description: "Diastolic blood pressure (mmHg)"
+        },
+        LDL_CHOLESTEROL: {
+          value: ldl,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 40, max: 260 },
+          description: "Low-density lipoprotein cholesterol"
+        },
+        HDL_CHOLESTEROL: {
+          value: hdl,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 20, max: 120 },
+          description: "High-density lipoprotein cholesterol"
+        },
+        TRIGLYCERIDES: {
+          value: triglycerides,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 40, max: 600 },
+          description: "Triglycerides (mg/dL)"
+        },
+        FASTING_GLUCOSE: {
+          value: fastingGlucose,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 60, max: 350 },
+          description: "Fasting plasma glucose"
+        },
+        HBA1C: {
+          value: hba1c,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 4.5, max: 14 },
+          description: "Hemoglobin A1c percentage"
+        },
+        EGFR: {
+          value: egfr,
+          durability: "stateful",
+          type: "number",
+          limits: { min: 5, max: 140 },
+          description: "Estimated glomerular filtration rate (mL/min/1.73m^2)"
+        },
+        SERUM_CREATININE: {
+          value: creatinine,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 0.4, max: 8 },
+          description: "Serum creatinine (mg/dL)"
+        },
+        URINE_ALBUMIN: {
+          value: urineAlbumin,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 0, max: 800 },
+          description: "Spot urine albumin-to-creatinine ratio (mg/g)"
+        },
+        RESPIRATORY_CAPACITY: {
+          value: respiratoryCapacity,
+          durability: "stateful",
+          type: "number",
+          limits: { min: 30, max: 120 },
+          description: "Estimated FEV1 percent predicted"
+        },
+        PHQ9_SCORE: {
+          value: Math.min(24, baselinePhq9),
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 0, max: 27 },
+          description: "Baseline Patient Health Questionnaire-9 score"
+        }
+      },
+      signals: {
+        metabolicSetpoint: bmi,
+        bpSetpoint: systolic,
+        lipidSetpoint: ldl,
+        renalBaseline: egfr,
+        renalDeclineRate: 0.8 + renalFactor * 1.2,
+        pulmonaryBaseline: respiratoryCapacity,
+        pulmonaryDeclineRate: 0.4 + respiratoryFactor * 1.1,
+        phq9Baseline: baselinePhq9,
+        metabolicFactor,
+        cardioFactor
+      }
+    };
+  },
+  update(p, ctx, deltaYears: number) {
+    const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+    const activity = ctx.get("activityScore") ?? 5;
+    const dietScore = ctx.get("dietScore") ?? 55;
+    const stress = ctx.get("stressIndex") ?? 0.3;
+    const smokingIntensity = ctx.get("smokingIntensity") ?? 0;
+    const packYears = ctx.get("smokingPackYears") ?? 0;
+    const metabolicFactor = ctx.get("metabolicFactor") ?? 0.5;
+    const cardioFactor = ctx.get("cardioFactor") ?? 0.5;
+    const adherence = ctx.get("t2dm_med_adherence") ?? 0;
+
+    const bmi = (p.attributes.BMI as number) ?? 26;
+    const bmiSetpoint = ctx.get("metabolicSetpoint") ?? bmi;
+    const bmiTarget = bmiSetpoint + (6 - activity) * 0.4 + (65 - dietScore) * 0.1 + stress * 0.6 - adherence * 1.2;
+    const bmiUpdated = clamp(bmi + (bmiTarget - bmi) * 0.15 * deltaYears, 16, 50);
+    ctx.setAttr("BMI", Number(bmiUpdated.toFixed(1)));
+
+    const systolic = (p.attributes.SYSTOLIC_BP as number) ?? 120;
+    const baselineSbp = ctx.get("bpSetpoint") ?? systolic;
+    const statinEffect = ctx.get("cad_statin_effect") ?? 0;
+    const antihypertensive = ctx.get("ckd_bp_control") ?? 0;
+    const sbpTarget = baselineSbp + stress * 6 + (bmiUpdated - bmiSetpoint) * 1.5 + smokingIntensity * 4 - antihypertensive * 8 - statinEffect * 2;
+    const sbpUpdated = clamp(systolic + (sbpTarget - systolic) * 0.2 * deltaYears, 95, 190);
+    ctx.setAttr("SYSTOLIC_BP", Math.round(sbpUpdated));
+    const diastolic = (p.attributes.DIASTOLIC_BP as number) ?? 75;
+    const dbpTarget = diastolic + (sbpTarget - systolic) * 0.5;
+    const dbpUpdated = clamp(diastolic + (dbpTarget - diastolic) * 0.18 * deltaYears, 50, 120);
+    ctx.setAttr("DIASTOLIC_BP", Math.round(dbpUpdated));
+
+    const a1cSignal = ctx.get("t2dm_a1c") ?? ((p.attributes.HBA1C as number) ?? 5.6);
+    const a1cNoise = ctx.rngNormal(0, 0.04);
+    ctx.setAttr("HBA1C", Number(clamp(a1cSignal + a1cNoise, 4.9, 11).toFixed(1)));
+
+    const fastingGlucose = (p.attributes.FASTING_GLUCOSE as number) ?? 95;
+    const glucoseTarget = clamp(95 + metabolicFactor * 10 + (a1cSignal - 6.2) * 18 - adherence * 25 + stress * 8, 75, 240);
+    const glucoseUpdated = clamp(fastingGlucose + (glucoseTarget - fastingGlucose) * 0.18 * deltaYears, 70, 260);
+    ctx.setAttr("FASTING_GLUCOSE", Math.round(glucoseUpdated));
+
+    const renalBaseline = ctx.get("renalBaseline") ?? ((p.attributes.EGFR as number) ?? 85);
+    const renalDeclineBase = (ctx.get("renalDeclineRate") ?? 1) * 0.34;
+    const age = ctx.now ?? 0;
+    const diabetesBurden = Math.max(0, a1cSignal - 6.8);
+    const bpBurden = Math.max(0, sbpUpdated - 132) / 35;
+    const ageRelatedDecline = Math.max(0, age - 60) * 0.005;
+    const renalDecline = (renalDeclineBase + diabetesBurden * 0.35 + bpBurden * 0.3 + ageRelatedDecline) * deltaYears;
+    const egfrCurrent = (p.attributes.EGFR as number) ?? renalBaseline;
+    const egfrUpdated = clamp(egfrCurrent - renalDecline, 15, 120);
+    ctx.setAttr("EGFR", Number(egfrUpdated.toFixed(1)));
+    const creatinine = clamp(0.6 + (110 - egfrUpdated) / 90, 0.5, 4.5);
+    ctx.setAttr("SERUM_CREATININE", Number(creatinine.toFixed(2)));
+    const albuminCurrent = (p.attributes.URINE_ALBUMIN as number) ?? 20;
+    const albuminTarget = clamp(20 + diabetesBurden * 50 + bpBurden * 40, 5, 400);
+    const albuminUpdated = clamp(albuminCurrent + (albuminTarget - albuminCurrent) * 0.18 * deltaYears, 5, 500);
+    ctx.setAttr("URINE_ALBUMIN", Number(albuminUpdated.toFixed(1)));
+    ctx.set("renal_function", egfrUpdated);
+
+    const pulmonaryBaseline = ctx.get("pulmonaryBaseline") ?? ((p.attributes.RESPIRATORY_CAPACITY as number) ?? 90);
+    const pulmonaryDecay = (ctx.get("pulmonaryDeclineRate") ?? 0.6) * 0.35 + smokingIntensity * 0.8 + (packYears > 30 ? 0.4 : 0) + (p.attributes.OCCUPATIONAL_EXPOSURE_DUST ? 0.25 : 0);
+    const pulmonaryCurrent = (p.attributes.RESPIRATORY_CAPACITY as number) ?? pulmonaryBaseline;
+    const pulmonaryTarget = pulmonaryBaseline - pulmonaryDecay * 5;
+    const pulmonaryUpdated = clamp(pulmonaryCurrent + (pulmonaryTarget - pulmonaryCurrent) * 0.12 * deltaYears, 40, 110);
+    ctx.setAttr("RESPIRATORY_CAPACITY", Math.round(pulmonaryUpdated));
+    ctx.set("pulmonary_capacity", pulmonaryUpdated);
+
+    const lipidSet = ctx.get("lipidSetpoint") ?? ((p.attributes.LDL_CHOLESTEROL as number) ?? 120);
+    const addon = (ctx.get("cad_addon_lipid") ?? 0) * 20;
+    const ldlCurrent = (p.attributes.LDL_CHOLESTEROL as number) ?? lipidSet;
+    const ldlTarget = clamp(lipidSet - statinEffect * 40 - addon + Math.max(0, 65 - dietScore) * 0.5 - activity * 0.6, 55, 190);
+    const ldlUpdated = clamp(ldlCurrent + (ldlTarget - ldlCurrent) * 0.2 * deltaYears, 55, 200);
+    ctx.setAttr("LDL_CHOLESTEROL", Math.round(ldlUpdated));
+
+    const hdlCurrent = (p.attributes.HDL_CHOLESTEROL as number) ?? 45;
+    const hdlTarget = clamp(hdlCurrent + (activity - 5) * 1.2 - smokingIntensity * 2.5 + metabolicFactor * -1.5, 30, 90);
+    const hdlUpdated = clamp(hdlCurrent + (hdlTarget - hdlCurrent) * 0.18 * deltaYears, 30, 95);
+    ctx.setAttr("HDL_CHOLESTEROL", Math.round(hdlUpdated));
+
+    const trigCurrent = (p.attributes.TRIGLYCERIDES as number) ?? 160;
+    const trigTarget = clamp(160 + Math.max(0, 65 - dietScore) * 2 - activity * 5 - statinEffect * 15 + metabolicFactor * 30, 90, 350);
+    const trigUpdated = clamp(trigCurrent + (trigTarget - trigCurrent) * 0.2 * deltaYears, 80, 380);
+    ctx.setAttr("TRIGLYCERIDES", Math.round(trigUpdated));
+
+    const moodSignal = ctx.get("mdd_phq9") ?? ((p.attributes.PHQ9_SCORE as number) ?? ctx.get("phq9Baseline") ?? 5);
+    const supportEffect = p.attributes.MENTAL_HEALTH_SUPPORT === "Regular" ? -2 : p.attributes.MENTAL_HEALTH_SUPPORT === "Occasional" ? -1 : 0;
+    const moodTarget = clamp(moodSignal + supportEffect - activity * 0.1 + stress * 1.5, 0, 24);
+    const moodUpdated = clamp((p.attributes.PHQ9_SCORE as number) ?? moodSignal + (moodTarget - moodSignal) * 0.2, 0, 27);
+    ctx.setAttr("PHQ9_SCORE", Math.round(moodUpdated));
+  },
+  test() {
+    const sample = this.generate(13579, 1960);
+    const attrs = sample.attributes;
+    const hasBmi = typeof attrs.BMI?.value === "number";
+    const hasEgfr = typeof attrs.EGFR?.value === "number";
+    return { passed: hasBmi && hasEgfr };
+  }
+};
+
+export default module;

--- a/worlds/clinical_suite/attributes/demographics.ts
+++ b/worlds/clinical_suite/attributes/demographics.ts
@@ -1,0 +1,145 @@
+import type { AttributeGroupModule } from "../../src/contracts";
+
+type RNG = () => number;
+
+function createRng(seed: number): RNG {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+const races = [
+  "White",
+  "Black or African American",
+  "Asian",
+  "American Indian or Alaska Native",
+  "Native Hawaiian or Other Pacific Islander",
+  "Other"
+];
+
+const educationLevels = [
+  "Less than high school",
+  "High school diploma",
+  "Some college",
+  "Bachelor's degree",
+  "Graduate degree"
+];
+
+const module: AttributeGroupModule = {
+  id: "DemographicsExtended",
+  category: "Demographics",
+  summary: "Expanded demographic context with socioeconomic and family history indicators.",
+  generate(seed: number, birthYear: number) {
+    const rng = createRng(seed ^ (birthYear * 131));
+    const age = 30 + Math.floor(rng() * 55);
+    const sex = rng() < 0.52 ? "F" : "M";
+    const race = races[Math.floor(rng() * races.length)];
+    const ethnicity = rng() < 0.18 ? "Hispanic or Latino" : "Not Hispanic or Latino";
+    const income = Math.round(28000 + rng() * 90000);
+    const educationIdx = Math.min(educationLevels.length - 1, Math.floor(rng() * educationLevels.length + (income > 80000 ? 1 : 0)));
+    const education = educationLevels[Math.max(0, educationIdx)];
+
+    const householdSize = 1 + Math.floor(rng() * 4);
+    const socioeconomicIndex = Math.min(100, Math.max(5, Math.round(income / 1500 + (educationIdx + 1) * 4 - householdSize * 2)));
+
+    const fhxDiabetes = rng() < 0.32;
+    const fhxCad = rng() < 0.28;
+
+    let insurance: string;
+    if (age >= 65) {
+      insurance = rng() < 0.7 ? "Medicare" : "Medicare Advantage";
+    } else if (income < 25000) {
+      insurance = rng() < 0.6 ? "Medicaid" : "Uninsured";
+    } else {
+      insurance = rng() < 0.2 ? "Exchange plan" : "Commercial";
+    }
+
+    const preventiveAdherence = Math.min(1, Math.max(0.1, socioeconomicIndex / 120 + (fhxCad ? 0.1 : 0) + (educationIdx >= 3 ? 0.1 : 0)));
+
+    return {
+      attributes: {
+        AGE_YEARS: {
+          value: age,
+          durability: "intrinsic",
+          type: "number",
+          limits: { min: 0, max: 120 },
+          description: "Age in years at simulation start"
+        },
+        SEX_AT_BIRTH: {
+          value: sex,
+          durability: "intrinsic",
+          type: "string",
+          description: "Sex assigned at birth"
+        },
+        RACE: {
+          value: race,
+          durability: "intrinsic",
+          type: "string",
+          description: "Self-identified race"
+        },
+        ETHNICITY: {
+          value: ethnicity,
+          durability: "intrinsic",
+          type: "string",
+          description: "Ethnicity per OMB standards"
+        },
+        HOUSEHOLD_INCOME: {
+          value: income,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 0, max: 250000 },
+          description: "Estimated annual household income (USD)"
+        },
+        HOUSEHOLD_SIZE: {
+          value: householdSize,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 1, max: 10 },
+          description: "Number of people living in the home"
+        },
+        EDUCATION_LEVEL: {
+          value: education,
+          durability: "semi_durable",
+          type: "string",
+          description: "Highest completed education level"
+        },
+        INSURANCE_TYPE: {
+          value: insurance,
+          durability: "semi_durable",
+          type: "string",
+          description: "Primary insurance coverage"
+        },
+        FAMILY_HISTORY_DIABETES: {
+          value: fhxDiabetes,
+          durability: "intrinsic",
+          type: "boolean",
+          description: "Family history of type 2 diabetes"
+        },
+        FAMILY_HISTORY_CAD: {
+          value: fhxCad,
+          durability: "intrinsic",
+          type: "boolean",
+          description: "Family history of coronary artery disease"
+        }
+      },
+      signals: {
+        socioeconomicIndex,
+        preventiveAdherence,
+        fhxDiabetes: fhxDiabetes ? 1 : 0,
+        fhxCad: fhxCad ? 1 : 0
+      },
+      sexAtBirth: sex as "M" | "F"
+    };
+  },
+  test() {
+    const sample = this.generate(12345, 1975);
+    const attrs = sample.attributes;
+    const hasCore = typeof attrs.AGE_YEARS?.value === "number" && typeof attrs.SEX_AT_BIRTH?.value === "string";
+    const hasSignals = typeof sample.signals?.socioeconomicIndex === "number";
+    return { passed: hasCore && hasSignals };
+  }
+};
+
+export default module;

--- a/worlds/clinical_suite/attributes/lifestyle.ts
+++ b/worlds/clinical_suite/attributes/lifestyle.ts
@@ -1,0 +1,117 @@
+import type { AttributeGroupModule } from "../../src/contracts";
+
+type RNG = () => number;
+
+function createRng(seed: number): RNG {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1103515245 + 12345) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+const alcoholLevels = ["None", "Low", "Moderate", "High"] as const;
+const mentalHealthSupport = ["None", "Occasional", "Regular"] as const;
+
+const module: AttributeGroupModule = {
+  id: "LifestyleProfile",
+  category: "Lifestyle",
+  summary: "Lifestyle behaviors, substance exposure, and protective factors impacting chronic disease risk.",
+  generate(seed: number, birthYear: number) {
+    const rng = createRng(seed + birthYear * 17);
+
+    const smokingRoll = rng();
+    let smokingStatus: "Never" | "Former" | "Current";
+    if (smokingRoll < 0.58) smokingStatus = "Never";
+    else if (smokingRoll < 0.82) smokingStatus = "Former";
+    else smokingStatus = "Current";
+
+    let packYears = 0;
+    if (smokingStatus === "Former") packYears = Number((rng() * 20 + 5).toFixed(1));
+    if (smokingStatus === "Current") packYears = Number((rng() * 30 + 10).toFixed(1));
+
+    const alcoholIdx = Math.min(alcoholLevels.length - 1, Math.floor(rng() * 4));
+    const activityScore = Math.round(2 + rng() * 8); // 0-10 scale
+    const dietScore = Math.round(35 + rng() * 50 - (smokingStatus === "Current" ? 8 : 0));
+    const sleepHours = Number((6 + rng() * 2.5).toFixed(1));
+    const exposureDust = rng() < 0.12 && smokingStatus !== "Never";
+    const mentalHealthIdx = Math.min(mentalHealthSupport.length - 1, Math.floor(rng() * 3));
+
+    const stressBase = 0.35 + (packYears / 80) + (alcoholIdx * 0.1) - activityScore / 18 - dietScore / 250 + (sleepHours < 6.5 ? 0.12 : -0.05);
+    const stressIndex = Math.min(1, Math.max(0.05, Number(stressBase.toFixed(2))));
+
+    return {
+      attributes: {
+        SMOKING_STATUS: {
+          value: smokingStatus,
+          durability: "semi_durable",
+          type: "string",
+          description: "Smoking status using standard categories"
+        },
+        SMOKING_PACK_YEARS: {
+          value: Number(packYears.toFixed(1)),
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 0, max: 120 },
+          description: "Cumulative pack-year exposure"
+        },
+        ALCOHOL_USE_LEVEL: {
+          value: alcoholLevels[alcoholIdx],
+          durability: "semi_durable",
+          type: "string",
+          description: "Average alcohol consumption level"
+        },
+        PHYSICAL_ACTIVITY_LEVEL: {
+          value: activityScore,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 0, max: 10 },
+          description: "Weekly physical activity score on a 0-10 scale"
+        },
+        DIET_QUALITY_SCORE: {
+          value: Math.max(10, Math.min(100, dietScore)),
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 0, max: 100 },
+          description: "Composite diet quality score (Healthy Eating Index style)"
+        },
+        SLEEP_HOURS: {
+          value: sleepHours,
+          durability: "semi_durable",
+          type: "number",
+          limits: { min: 3, max: 12 },
+          description: "Average nightly sleep duration"
+        },
+        OCCUPATIONAL_EXPOSURE_DUST: {
+          value: exposureDust,
+          durability: "semi_durable",
+          type: "boolean",
+          description: "Regular occupational exposure to dust or fumes"
+        },
+        MENTAL_HEALTH_SUPPORT: {
+          value: mentalHealthSupport[mentalHealthIdx],
+          durability: "semi_durable",
+          type: "string",
+          description: "Baseline access to supportive counseling or therapy"
+        }
+      },
+      signals: {
+        smokingPackYears: packYears,
+        smokingIntensity: smokingStatus === "Current" ? 1 : smokingStatus === "Former" ? 0.4 : 0,
+        activityScore,
+        dietScore: Math.max(10, Math.min(100, dietScore)),
+        sleepQuality: sleepHours / 8,
+        stressIndex
+      }
+    };
+  },
+  test() {
+    const sample = this.generate(9876, 1965);
+    const attrs = sample.attributes;
+    const hasSmoking = typeof attrs.SMOKING_STATUS?.value === "string";
+    const hasPackYears = typeof attrs.SMOKING_PACK_YEARS?.value === "number";
+    return { passed: hasSmoking && hasPackYears };
+  }
+};
+
+export default module;

--- a/worlds/clinical_suite/diseases/ckd.ts
+++ b/worlds/clinical_suite/diseases/ckd.ts
@@ -1,0 +1,142 @@
+import type { DiseaseModule } from "../../src/contracts";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function stageFromEgfr(egfr: number): number {
+  if (egfr >= 60) return 2;
+  if (egfr >= 45) return 3;
+  if (egfr >= 30) return 3.5;
+  if (egfr >= 15) return 4;
+  return 5;
+}
+
+const module: DiseaseModule = {
+  id: "ChronicKidneyDisease",
+  version: "1.0.0",
+  summary: "Chronic kidney disease progression with albuminuria monitoring and renoprotective therapy.",
+  init(p, ctx) {
+    const egfr = (p.attributes.EGFR as number) ?? 85;
+    ctx.set("ckd_stage", stageFromEgfr(egfr));
+    ctx.set("ckd_next_lab", ctx.now + 0.6);
+    ctx.set("ckd_ultrasound_done", 0);
+    ctx.set("ckd_bp_control", ctx.get("ckd_bp_control") ?? 0);
+  },
+  eligible(p) {
+    const age = (p.attributes.AGE_YEARS as number) ?? 0;
+    const egfr = (p.attributes.EGFR as number) ?? 90;
+    const albumin = (p.attributes.URINE_ALBUMIN as number) ?? 15;
+    return age >= 35 && (egfr < 90 || albumin > 30 || p.diagnoses["E11.9"] || ((p.attributes.SYSTOLIC_BP as number) ?? 0) > 140);
+  },
+  risk(p, ctx) {
+    const egfr = (p.attributes.EGFR as number) ?? 95;
+    const albumin = (p.attributes.URINE_ALBUMIN as number) ?? 10;
+    const diabetes = p.diagnoses["E11.9"] ? 1 : 0;
+    const bp = (p.attributes.SYSTOLIC_BP as number) ?? 120;
+    const egfrLoad = clamp((75 - egfr) * 0.002, 0, 0.12);
+    const albuminLoad = clamp((albumin - 80) * 0.0004, 0, 0.06);
+    const bpLoad = Math.max(0, bp - 140) * 0.00035;
+    const base = 0.0015 + egfrLoad + albuminLoad + diabetes * 0.011 + bpLoad;
+    return clamp(base, 0.0005, 0.25);
+  },
+  step(p, ctx) {
+    const diagnosed = !!p.diagnoses["N18.3"] || !!p.diagnoses["N18.4"] || !!p.diagnoses["N18.5"];
+    const monthlyRisk = this.risk(p, ctx) / 12;
+    const egfr = (p.attributes.EGFR as number) ?? 90;
+    const stage = stageFromEgfr(egfr);
+
+    const significantImpairment = stage >= 3 || (p.attributes.URINE_ALBUMIN as number) > 280;
+    const severityFactor = stage >= 5 ? 1.2 : stage >= 4 ? 1 : stage >= 3 ? 1 : 0;
+
+    if (!diagnosed && significantImpairment && ctx.rngUniform() < Math.min(1, monthlyRisk * Math.max(0.35, severityFactor))) {
+      const code = stage >= 5 ? "N18.5" : stage >= 4 ? "N18.4" : "N18.3";
+      const name =
+        stage >= 5
+          ? "Chronic kidney disease stage 5"
+          : stage >= 4
+          ? "Chronic kidney disease stage 4"
+          : "Chronic kidney disease stage 3";
+      ctx.emit({ type: "diagnosis", payload: { code, name } });
+      p.diagnoses[code] = 1;
+      const egfrLab = Number(((p.attributes.EGFR as number) ?? egfr).toFixed(1));
+      const creat = Number(((p.attributes.SERUM_CREATININE as number) ?? 1.1).toFixed(2));
+      const albuminBaseline = Number(((p.attributes.URINE_ALBUMIN as number) ?? 35).toFixed(1));
+      ctx.emit({ type: "lab", payload: { id: "LAB_EGFR", name: "Estimated GFR", value: egfrLab } });
+      ctx.emit({ type: "lab", payload: { id: "LAB_CREAT", name: "Serum creatinine", value: creat } });
+      ctx.emit({ type: "lab", payload: { id: "LAB_UACR", name: "Urine albumin/creatinine", value: albuminBaseline } });
+      if (!p.medsOn["ACE Inhibitor"]) {
+        ctx.emit({ type: "medication", payload: { drug: "Lisinopril", dose: "10 mg daily" } });
+        p.medsOn["ACE Inhibitor"] = 1;
+        ctx.set("ckd_bp_control", (ctx.get("ckd_bp_control") ?? 0) + 0.5);
+      }
+      ctx.set("ckd_stage", stage);
+      ctx.set("ckd_next_lab", ctx.now + 0.33);
+    }
+
+    if (diagnosed && stage >= 4 && !p.medsOn["SGLT2 inhibitor"] && (p.diagnoses["E11.9"] || ctx.rngUniform() < 0.35)) {
+      ctx.emit({ type: "medication", payload: { drug: "Empagliflozin", dose: "10 mg daily" } });
+      p.medsOn["SGLT2 inhibitor"] = 1;
+      ctx.set("t2dm_med_adherence", Math.min(0.95, (ctx.get("t2dm_med_adherence") ?? 0.6) + 0.05));
+    }
+
+    const nextLab = ctx.get("ckd_next_lab") ?? (ctx.now + 0.6);
+    if (ctx.now >= nextLab - 1e-6 && (diagnosed || egfr < 75)) {
+      const egfrLab = clamp(egfr + ctx.rngNormal(0, 3), 8, 120);
+      const creat = clamp((p.attributes.SERUM_CREATININE as number) + ctx.rngNormal(0, 0.2), 0.5, 7);
+      const albumin = clamp((p.attributes.URINE_ALBUMIN as number) + ctx.rngNormal(0, 8), 5, 800);
+      ctx.emit({ type: "lab", payload: { id: "LAB_EGFR", name: "Estimated GFR", value: Number(egfrLab.toFixed(1)) } });
+      ctx.emit({ type: "lab", payload: { id: "LAB_CREAT", name: "Serum creatinine", value: Number(creat.toFixed(2)) } });
+      ctx.emit({ type: "lab", payload: { id: "LAB_UACR", name: "Urine albumin/creatinine", value: Number(albumin.toFixed(1)) } });
+      ctx.set("ckd_next_lab", ctx.now + (egfr < 45 ? 0.33 : 0.5));
+    }
+
+    if (diagnosed && !ctx.get("ckd_ultrasound_done") && ctx.rngUniform() < 0.1) {
+      ctx.emit({ type: "procedure", payload: { code: "76770", name: "Renal ultrasound" } });
+      ctx.set("ckd_ultrasound_done", 1);
+    }
+
+    if (stage >= 4 && ctx.rngUniform() < 0.02) {
+      ctx.emit({ type: "encounter", payload: { kind: "Specialty" } });
+    }
+
+    if (stage >= 5 && ctx.rngUniform() < 0.05) {
+      ctx.emit({ type: "procedure", payload: { code: "90935", name: "Hemodialysis session" } });
+      if (!p.medsOn["Erythropoietin"]) {
+        ctx.emit({ type: "medication", payload: { drug: "Erythropoietin", dose: "Weekly" } });
+        p.medsOn["Erythropoietin"] = 1;
+      }
+    }
+  },
+  test() {
+    const patient: any = {
+      attributes: {
+        AGE_YEARS: 72,
+        EGFR: 42,
+        URINE_ALBUMIN: 180,
+        SYSTOLIC_BP: 150,
+        SERUM_CREATININE: 1.9
+      },
+      diagnoses: { "E11.9": 1 },
+      medsOn: {},
+      signals: { ckd_next_lab: 0.1 }
+    };
+    const events: any[] = [];
+    const ctx: any = {
+      now: 60,
+      rngUniform: () => 0,
+      rngNormal: () => 0,
+      emit: (e: any) => events.push(e),
+      schedule: () => {},
+      get: (k: string) => patient.signals[k],
+      set: (k: string, v: number) => {
+        patient.signals[k] = v;
+      }
+    };
+    this.init!(patient, ctx);
+    this.step(patient, ctx);
+    return { passed: events.some((e) => e.type === "diagnosis" || e.type === "lab") };
+  }
+};
+
+export default module;

--- a/worlds/clinical_suite/diseases/copd.ts
+++ b/worlds/clinical_suite/diseases/copd.ts
@@ -1,0 +1,109 @@
+import type { DiseaseModule } from "../../src/contracts";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+const module: DiseaseModule = {
+  id: "ChronicObstructivePulmonaryDisease",
+  version: "1.0.0",
+  summary: "COPD progression with spirometry surveillance, exacerbations, and inhaler management.",
+  init(p, ctx) {
+    const baseline = (p.attributes.RESPIRATORY_CAPACITY as number) ?? 90;
+    ctx.set("copd_baseline", baseline);
+    ctx.set("copd_next_spirometry", ctx.now + 1.1);
+    ctx.set("copd_exacerbation_rate", 0.02);
+  },
+  eligible(p) {
+    const age = (p.attributes.AGE_YEARS as number) ?? 0;
+    const packYears = (p.attributes.SMOKING_PACK_YEARS as number) ?? 0;
+    const exposure = !!p.attributes.OCCUPATIONAL_EXPOSURE_DUST;
+    return age >= 40 && (packYears > 5 || exposure);
+  },
+  risk(p, ctx) {
+    const packYears = (p.attributes.SMOKING_PACK_YEARS as number) ?? (ctx.get("smokingPackYears") ?? 0);
+    const capacity = ctx.get("pulmonary_capacity") ?? ((p.attributes.RESPIRATORY_CAPACITY as number) ?? 90);
+    const exposure = p.attributes.OCCUPATIONAL_EXPOSURE_DUST ? 1 : 0;
+    const base = 0.008 + packYears * 0.0018 + exposure * 0.02 + clamp((80 - capacity) * 0.002, 0, 0.2);
+    return clamp(base, 0.001, 0.35);
+  },
+  step(p, ctx) {
+    const diagnosed = !!p.diagnoses["J44.9"];
+    const monthlyRisk = this.risk(p, ctx) / 12;
+    const capacity = ctx.get("pulmonary_capacity") ?? ((p.attributes.RESPIRATORY_CAPACITY as number) ?? 90);
+
+    if (!diagnosed && ctx.rngUniform() < monthlyRisk) {
+      ctx.emit({ type: "diagnosis", payload: { code: "J44.9", name: "Chronic obstructive pulmonary disease" } });
+      p.diagnoses["J44.9"] = 1;
+      ctx.emit({ type: "lab", payload: { id: "SPIRO_FEV1", name: "Spirometry FEV1 % predicted", value: Math.round(capacity) } });
+      if (!p.medsOn["LAMA"]) {
+        ctx.emit({ type: "medication", payload: { drug: "Tiotropium inhaler", dose: "18 mcg daily" } });
+        p.medsOn["LAMA"] = 1;
+      }
+      ctx.emit({ type: "medication", payload: { drug: "Albuterol inhaler", dose: "2 puffs q4h PRN" } });
+      p.medsOn["SABA"] = 1;
+      ctx.set("copd_next_spirometry", ctx.now + 0.75);
+      ctx.set("copd_exacerbation_rate", 0.04);
+    }
+
+    const exacerbationRate = ctx.get("copd_exacerbation_rate") ?? 0.02;
+    const severity = clamp(1 - capacity / 100, 0, 0.9);
+    const exacerbationProb = clamp(exacerbationRate + severity * 0.08, 0.005, 0.18);
+    if (diagnosed && ctx.rngUniform() < exacerbationProb) {
+      const severe = ctx.rngUniform() < 0.35 || capacity < 45;
+      ctx.emit({ type: "encounter", payload: { kind: severe ? "Inpatient" : "ED" } });
+      ctx.emit({ type: "procedure", payload: { code: "94640", name: "Nebulizer treatment" } });
+      ctx.emit({ type: "medication", payload: { drug: "Prednisone", dose: "40 mg taper" } });
+      ctx.set("copd_exacerbation_rate", clamp(exacerbationRate + 0.008, 0.02, 0.12));
+      if (!p.medsOn["Inhaled corticosteroid"] && (severity > 0.3 || ctx.rngUniform() < 0.3)) {
+        ctx.emit({ type: "medication", payload: { drug: "Budesonide-formoterol", dose: "160/4.5 mcg BID" } });
+        p.medsOn["Inhaled corticosteroid"] = 1;
+      }
+      if (severe && !p.medsOn["Home oxygen"] && capacity < 45 && ctx.rngUniform() < 0.3) {
+        ctx.emit({ type: "medication", payload: { drug: "Home oxygen", dose: "2 L/min" } });
+        p.medsOn["Home oxygen"] = 1;
+      }
+    }
+
+    const nextSpirometry = ctx.get("copd_next_spirometry") ?? (ctx.now + 1);
+    if (ctx.now >= nextSpirometry - 1e-6 && (diagnosed || capacity < 65)) {
+      const value = clamp(capacity + ctx.rngNormal(0, 4), 30, 110);
+      ctx.emit({ type: "lab", payload: { id: "SPIRO_FEV1", name: "Spirometry FEV1 % predicted", value: Math.round(value) } });
+      ctx.set("copd_next_spirometry", ctx.now + 1);
+    }
+
+    if (!diagnosed && (p.attributes.SMOKING_STATUS === "Current") && ctx.rngUniform() < 0.02) {
+      ctx.emit({ type: "procedure", payload: { code: "71250", name: "Low-dose CT lung cancer screening" } });
+    }
+  },
+  test() {
+    const patient: any = {
+      attributes: {
+        AGE_YEARS: 64,
+        SMOKING_PACK_YEARS: 45,
+        RESPIRATORY_CAPACITY: 55,
+        OCCUPATIONAL_EXPOSURE_DUST: true
+      },
+      diagnoses: {},
+      medsOn: {},
+      signals: { pulmonary_capacity: 55 }
+    };
+    const events: any[] = [];
+    const ctx: any = {
+      now: 50,
+      rngUniform: () => 0,
+      rngNormal: () => 0,
+      emit: (e: any) => events.push(e),
+      schedule: () => {},
+      get: (k: string) => patient.signals[k],
+      set: (k: string, v: number) => {
+        patient.signals[k] = v;
+      }
+    };
+    this.init!(patient, ctx);
+    this.step(patient, ctx);
+    return { passed: events.some((e) => e.type === "diagnosis") };
+  }
+};
+
+export default module;

--- a/worlds/clinical_suite/diseases/coronary_artery_disease.ts
+++ b/worlds/clinical_suite/diseases/coronary_artery_disease.ts
@@ -1,0 +1,157 @@
+import type { DiseaseModule } from "../../src/contracts";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+const module: DiseaseModule = {
+  id: "CoronaryArteryDisease",
+  version: "1.0.0",
+  summary: "Stable coronary artery disease with lipid management, angina episodes, and cardiac testing.",
+  init(p, ctx) {
+    ctx.set("cad_angina_burden", 0);
+    ctx.set("cad_next_lipid", ctx.now + 1);
+    ctx.set("cad_next_stress", ctx.now + (0.8 + ctx.rngUniform() * 0.6));
+    ctx.set("cad_statin_effect", 0);
+    ctx.set("cad_addon_lipid", 0);
+    ctx.set("cad_next_statin_review", ctx.now + 1);
+  },
+  eligible(p) {
+    return ((p.attributes.AGE_YEARS as number) ?? 0) >= 40;
+  },
+  risk(p, ctx) {
+    const age = (p.attributes.AGE_YEARS as number) ?? 50;
+    const sex = p.sexAtBirth ?? "U";
+    const ldl = (p.attributes.LDL_CHOLESTEROL as number) ?? 120;
+    const sbp = (p.attributes.SYSTOLIC_BP as number) ?? 120;
+    const smoking = ctx.get("smokingPackYears") ?? 0;
+    const diabetes = p.diagnoses["E11.9"] ? 1 : 0;
+    const fhx = ctx.get("fhxCad") ?? 0;
+    const stress = ctx.get("stressIndex") ?? 0.3;
+    const ageLoad = Math.max(0, age - 50) * 0.0009;
+    const lipidLoad = Math.max(0, ldl - 120) * 0.00035;
+    const pressureLoad = Math.max(0, sbp - 135) * 0.0004;
+    const smokingLoad = Math.min(60, smoking) * 0.00035;
+    const base =
+      0.004 +
+      ageLoad +
+      (sex === "M" ? 0.004 : 0) +
+      lipidLoad +
+      pressureLoad +
+      smokingLoad +
+      diabetes * 0.012 +
+      fhx * 0.014 +
+      stress * 0.006;
+    const protective = Math.max(0, (ctx.get("activityScore") ?? 5) - 6) * 0.0008;
+    return clamp(base - protective, 0.001, 0.25);
+  },
+  step(p, ctx) {
+    const diagnosed = !!p.diagnoses["I25.10"];
+    const monthlyRisk = this.risk(p, ctx) / 12;
+    const anginaBurden = ctx.get("cad_angina_burden") ?? 0;
+
+    if (!diagnosed && ctx.rngUniform() < monthlyRisk) {
+      ctx.emit({ type: "diagnosis", payload: { code: "I25.10", name: "Coronary artery disease without angina" } });
+      p.diagnoses["I25.10"] = 1;
+      ctx.emit({ type: "procedure", payload: { code: "93454", name: "Coronary angiography" } });
+      ctx.set("cad_angina_burden", 0.35);
+      if (!p.medsOn["High-intensity statin"]) {
+        const startHighIntensity = ctx.rngUniform() < 0.86;
+        ctx.emit({
+          type: "medication",
+          payload: { drug: startHighIntensity ? "Atorvastatin" : "Simvastatin", dose: startHighIntensity ? "40 mg nightly" : "20 mg nightly" }
+        });
+        p.medsOn["High-intensity statin"] = startHighIntensity ? 1 : 0;
+        ctx.set("cad_statin_effect", startHighIntensity ? 0.68 : 0.38);
+      }
+      if (!p.medsOn["Aspirin"] && ctx.rngUniform() < 0.9) {
+        ctx.emit({ type: "medication", payload: { drug: "Aspirin", dose: "81 mg daily" } });
+        p.medsOn["Aspirin"] = 1;
+      }
+      ctx.set("cad_next_lipid", ctx.now + 0.5);
+      ctx.set("cad_next_statin_review", ctx.now + 0.75);
+    }
+
+    const anginaProb = clamp(anginaBurden * 0.02 + (diagnosed ? 0.006 : 0), 0, 0.08);
+    if (ctx.rngUniform() < anginaProb) {
+      const acute = ctx.rngUniform() < 0.25;
+      ctx.emit({ type: "encounter", payload: { kind: acute ? "ED" : "Specialty" } });
+      ctx.emit({ type: "procedure", payload: { code: acute ? "92950" : "93000", name: acute ? "Acute coronary care" : "Resting ECG" } });
+      ctx.set("cad_angina_burden", clamp(anginaBurden + (acute ? 0.12 : 0.035), 0, 1.2));
+    } else {
+      ctx.set("cad_angina_burden", Math.max(0.04, anginaBurden * 0.94));
+    }
+
+    const nextLipid = ctx.get("cad_next_lipid") ?? (ctx.now + 1);
+    if (ctx.now >= nextLipid - 1e-6 && (diagnosed || ctx.rngUniform() < 0.3)) {
+      const ldl = clamp(((p.attributes.LDL_CHOLESTEROL as number) ?? 120) - (ctx.get("cad_statin_effect") ?? 0) * 35 - (ctx.get("cad_addon_lipid") ?? 0) * 18 + ctx.rngNormal(0, 8), 40, 220);
+      const hdl = clamp(((p.attributes.HDL_CHOLESTEROL as number) ?? 45) + ctx.rngNormal(0, 4), 20, 120);
+      const trig = clamp(((p.attributes.TRIGLYCERIDES as number) ?? 150) + ctx.rngNormal(0, 18), 40, 600);
+      ctx.emit({ type: "lab", payload: { id: "LIPID_LDL", name: "LDL cholesterol", value: Math.round(ldl) } });
+      ctx.emit({ type: "lab", payload: { id: "LIPID_HDL", name: "HDL cholesterol", value: Math.round(hdl) } });
+      ctx.emit({ type: "lab", payload: { id: "LIPID_TG", name: "Triglycerides", value: Math.round(trig) } });
+      ctx.set("cad_next_lipid", ctx.now + (ldl > 100 ? 0.5 : 1));
+    }
+
+    let statinEffect = ctx.get("cad_statin_effect") ?? 0;
+    const ldlCurrent = (p.attributes.LDL_CHOLESTEROL as number) ?? 120;
+    const nextStatinReview = ctx.get("cad_next_statin_review") ?? (ctx.now + 1);
+    if (diagnosed && ctx.now >= nextStatinReview - 1e-6) {
+      if (statinEffect < 0.8 && ldlCurrent > 95 && ctx.rngUniform() < 0.12) {
+        ctx.emit({ type: "medication", payload: { drug: "Rosuvastatin", dose: "20 mg nightly" } });
+        p.medsOn["High-intensity statin"] = 1;
+        statinEffect = 0.9;
+        ctx.set("cad_statin_effect", statinEffect);
+      }
+      ctx.set("cad_next_statin_review", ctx.now + 1.2);
+    }
+
+    const currentLdl = ldlCurrent;
+    if (diagnosed && statinEffect >= 0.8 && (ctx.get("cad_addon_lipid") ?? 0) < 0.5 && currentLdl > 90 && ctx.now >= nextStatinReview - 1e-6 && ctx.rngUniform() < 0.08) {
+      ctx.emit({ type: "medication", payload: { drug: "Ezetimibe", dose: "10 mg daily" } });
+      ctx.set("cad_addon_lipid", 0.5);
+    }
+
+    const nextStress = ctx.get("cad_next_stress") ?? (ctx.now + 1.4);
+    if (ctx.now >= nextStress - 1e-6 && (diagnosed || anginaBurden > 0.45)) {
+      ctx.emit({ type: "procedure", payload: { code: "93015", name: "Cardiac stress test" } });
+      ctx.set("cad_next_stress", ctx.now + 1.7 + ctx.rngUniform() * 0.3);
+    }
+
+    if (diagnosed && ctx.rngUniform() < 0.006 && (ctx.get("cad_angina_burden") ?? 0) > 1.1) {
+      ctx.emit({ type: "encounter", payload: { kind: "Inpatient" } });
+      ctx.emit({ type: "procedure", payload: { code: "92928", name: "Percutaneous coronary intervention" } });
+      ctx.set("cad_angina_burden", 0.4);
+    }
+  },
+  test() {
+    const patient: any = {
+      attributes: {
+        AGE_YEARS: 67,
+        LDL_CHOLESTEROL: 160,
+        SYSTOLIC_BP: 150
+      },
+      diagnoses: { "E11.9": 1 },
+      medsOn: {},
+      sexAtBirth: "M",
+      signals: { stressIndex: 0.5, smokingPackYears: 25, fhxCad: 1 }
+    };
+    const events: any[] = [];
+    const ctx: any = {
+      now: 50,
+      rngUniform: () => 0,
+      rngNormal: () => 0,
+      emit: (e: any) => events.push(e),
+      schedule: () => {},
+      get: (k: string) => patient.signals[k],
+      set: (k: string, v: number) => {
+        patient.signals[k] = v;
+      }
+    };
+    this.init!(patient, ctx);
+    this.step(patient, ctx);
+    return { passed: events.some((e) => e.type === "diagnosis" || e.type === "medication") };
+  }
+};
+
+export default module;

--- a/worlds/clinical_suite/diseases/mdd.ts
+++ b/worlds/clinical_suite/diseases/mdd.ts
@@ -1,0 +1,119 @@
+import type { DiseaseModule } from "../../src/contracts";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+const module: DiseaseModule = {
+  id: "MajorDepressiveDisorder",
+  version: "1.0.0",
+  summary: "Recurrent major depressive disorder with symptom monitoring, therapy encounters, and pharmacotherapy escalation.",
+  init(p, ctx) {
+    const baseline = (p.attributes.PHQ9_SCORE as number) ?? 5;
+    ctx.set("mdd_phq9", baseline);
+    ctx.set("mdd_next_screen", ctx.now + 1);
+    ctx.set("mdd_next_therapy", ctx.now + 0.5);
+  },
+  eligible(p) {
+    return ((p.attributes.AGE_YEARS as number) ?? 0) >= 18;
+  },
+  risk(p, ctx) {
+    const stress = ctx.get("stressIndex") ?? 0.3;
+    const socioeconomic = ctx.get("socioeconomicIndex") ?? 55;
+    const support = p.attributes.MENTAL_HEALTH_SUPPORT === "Regular" ? -0.015 : p.attributes.MENTAL_HEALTH_SUPPORT === "Occasional" ? -0.008 : 0;
+    const chronicBurden =
+      (p.diagnoses["E11.9"] ? 0.01 : 0) +
+      (p.diagnoses["I25.10"] ? 0.012 : 0) +
+      (p.diagnoses["N18.3"] || p.diagnoses["N18.4"] || p.diagnoses["N18.5"] ? 0.015 : 0);
+    const sleep = (p.attributes.SLEEP_HOURS as number) ?? 7;
+    const base =
+      0.0035 +
+      stress * 0.03 +
+      chronicBurden +
+      (sleep < 6.5 ? 0.006 : 0) +
+      (socioeconomic < 40 ? 0.01 : 0) +
+      support;
+    const resilience = Math.max(0, (ctx.get("activityScore") ?? 5) - 6) * 0.0015;
+    return clamp(base - resilience, 0.0008, 0.22);
+  },
+  step(p, ctx) {
+    const diagnosed = !!p.diagnoses["F33.1"];
+    const monthlyRisk = this.risk(p, ctx) / 12;
+    const stress = ctx.get("stressIndex") ?? 0.3;
+    const sleepQuality = ctx.get("sleepQuality") ?? ((p.attributes.SLEEP_HOURS as number) ?? 7) / 8;
+    const activity = ctx.get("activityScore") ?? 5;
+    const supportSignal = p.attributes.MENTAL_HEALTH_SUPPORT === "Regular" ? 0.2 : p.attributes.MENTAL_HEALTH_SUPPORT === "Occasional" ? 0.1 : 0;
+
+    if (!diagnosed && ctx.rngUniform() < monthlyRisk) {
+      ctx.emit({ type: "diagnosis", payload: { code: "F33.1", name: "Recurrent major depressive disorder, moderate" } });
+      p.diagnoses["F33.1"] = 1;
+      const baseline = (p.attributes.PHQ9_SCORE as number) ?? 8;
+      ctx.set("mdd_phq9", clamp(baseline + 3, 8, 24));
+      if (!p.medsOn["SSRI"]) {
+        ctx.emit({ type: "medication", payload: { drug: "Sertraline", dose: "50 mg daily" } });
+        p.medsOn["SSRI"] = 1;
+      }
+      ctx.set("mdd_next_screen", ctx.now + 0.25);
+      ctx.set("mdd_next_therapy", ctx.now + 0.7 + (supportSignal > 0 ? 0.3 : 0));
+      ctx.schedule(0.08, { type: "encounter", payload: { kind: "Specialty" } });
+      ctx.schedule(0.08, { type: "procedure", payload: { code: "90837", name: "Psychotherapy 60 minutes" } });
+    }
+
+    let phq9 = ctx.get("mdd_phq9") ?? ((p.attributes.PHQ9_SCORE as number) ?? 5);
+    const medAdherence = p.medsOn["SSRI"] ? 0.65 + ctx.rngUniform() * 0.2 : 0;
+    const therapyEffect = supportSignal + (diagnosed ? 0.05 : 0);
+    const upward = stress * 8 + (1 - sleepQuality) * 4 + Math.max(0, 6 - activity) * 0.8;
+    const downward = medAdherence * 3 + therapyEffect * 2;
+    phq9 = clamp(phq9 + (upward - downward) * 0.05, 0, 27);
+    ctx.set("mdd_phq9", phq9);
+
+    if (diagnosed && phq9 > 14 && !p.medsOn["Augmentation"] && ctx.rngUniform() < 0.25) {
+      ctx.emit({ type: "medication", payload: { drug: "Bupropion", dose: "150 mg daily" } });
+      p.medsOn["Augmentation"] = 1;
+    }
+
+    const nextScreen = ctx.get("mdd_next_screen") ?? (ctx.now + 0.75);
+    if (ctx.now >= nextScreen - 1e-6) {
+      const score = clamp(phq9 + ctx.rngNormal(0, 1.5), 0, 27);
+      ctx.emit({ type: "lab", payload: { id: "PHQ9", name: "PHQ-9 depression score", value: Number(score.toFixed(0)) } });
+      ctx.set("mdd_next_screen", ctx.now + (diagnosed ? 0.33 : 0.75));
+    }
+
+    const nextTherapy = ctx.get("mdd_next_therapy") ?? (ctx.now + 0.7);
+    if (diagnosed && ctx.now >= nextTherapy - 1e-6) {
+      ctx.emit({ type: "encounter", payload: { kind: "Specialty" } });
+      ctx.emit({ type: "procedure", payload: { code: "90837", name: "Psychotherapy 60 minutes" } });
+      ctx.set("mdd_next_therapy", ctx.now + 0.7 + (supportSignal > 0 ? 0.3 : 0));
+    }
+  },
+  test() {
+    const patient: any = {
+      attributes: {
+        AGE_YEARS: 40,
+        PHQ9_SCORE: 9,
+        SLEEP_HOURS: 6,
+        MENTAL_HEALTH_SUPPORT: "None"
+      },
+      diagnoses: {},
+      medsOn: {},
+      signals: { stressIndex: 0.8, sleepQuality: 0.7, activityScore: 3, socioeconomicIndex: 32 }
+    };
+    const events: any[] = [];
+    const ctx: any = {
+      now: 30,
+      rngUniform: () => 0,
+      rngNormal: () => 0,
+      emit: (e: any) => events.push(e),
+      schedule: () => {},
+      get: (k: string) => patient.signals[k],
+      set: (k: string, v: number) => {
+        patient.signals[k] = v;
+      }
+    };
+    this.init!(patient, ctx);
+    this.step(patient, ctx);
+    return { passed: events.some((e) => e.type === "diagnosis") };
+  }
+};
+
+export default module;

--- a/worlds/clinical_suite/diseases/type2_diabetes.ts
+++ b/worlds/clinical_suite/diseases/type2_diabetes.ts
@@ -1,0 +1,145 @@
+import type { DiseaseModule } from "../../src/contracts";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+const module: DiseaseModule = {
+  id: "Type2DiabetesMellitus",
+  version: "1.0.0",
+  summary: "Progressive type 2 diabetes model with labs, medications, and complication surveillance.",
+  init(p, ctx) {
+    const baselineA1c = typeof p.attributes.HBA1C === "number" ? (p.attributes.HBA1C as number) : 5.6;
+    ctx.set("t2dm_a1c", baselineA1c);
+    ctx.set("t2dm_med_adherence", 0);
+    ctx.set("t2dm_next_lab", ctx.now + 0.75);
+    ctx.set("t2dm_next_eye", ctx.now + 1.2);
+  },
+  eligible(p) {
+    const age = (p.attributes.AGE_YEARS as number) ?? 0;
+    return age >= 30;
+  },
+  risk(p, ctx) {
+    const bmi = (p.attributes.BMI as number) ?? 26;
+    const glucose = (p.attributes.FASTING_GLUCOSE as number) ?? 95;
+    const fhx = p.attributes.FAMILY_HISTORY_DIABETES ? 1 : 0;
+    const stress = ctx.get("stressIndex") ?? 0.3;
+    const activity = ctx.get("activityScore") ?? 5;
+    const diet = ctx.get("dietScore") ?? 55;
+    const obesityLoad = clamp((bmi - 32) / 12, 0, 1);
+    const glycemicLoad = clamp((glucose - 115) / 120, 0, 1);
+    const lifestyleLift = Math.max(0, 70 - diet) * 0.0004 + Math.max(0, 6 - activity) * 0.001;
+    const base =
+      0.0015 +
+      obesityLoad * 0.012 +
+      glycemicLoad * 0.014 +
+      fhx * 0.006 +
+      stress * 0.004 +
+      lifestyleLift;
+    const protective = Math.max(0, diet - 75) * 0.0007 + Math.max(0, activity - 7) * 0.0015;
+    return clamp(base - protective, 0.0005, 0.08);
+  },
+  step(p, ctx) {
+    const diagnosed = !!p.diagnoses["E11.9"];
+    const monthlyRisk = this.risk(p, ctx) / 12;
+    const bmi = (p.attributes.BMI as number) ?? 26;
+    const diet = ctx.get("dietScore") ?? 55;
+    const activity = ctx.get("activityScore") ?? 5;
+    const stress = ctx.get("stressIndex") ?? 0.3;
+
+    if (!diagnosed && ctx.rngUniform() < monthlyRisk) {
+      ctx.emit({ type: "diagnosis", payload: { code: "E11.9", name: "Type 2 diabetes mellitus without complications" } });
+      p.diagnoses["E11.9"] = 1;
+      const adherence =
+        0.55 +
+        ctx.rngUniform() * 0.35 +
+        ((ctx.get("preventiveAdherence") ?? 0.2) * 0.2);
+      ctx.set("t2dm_med_adherence", clamp(adherence, 0.4, 0.95));
+      ctx.set("t2dm_a1c", clamp(((p.attributes.HBA1C as number) ?? 6.8) + 0.2, 6.4, 9.2));
+      ctx.emit({ type: "lab", payload: { id: "A1C", name: "Hemoglobin A1c", value: Number(((p.attributes.HBA1C as number) ?? 6.9 + 0.2).toFixed(1)) } });
+      const baselineGlucose = (p.attributes.FASTING_GLUCOSE as number) ?? 150;
+      ctx.emit({ type: "lab", payload: { id: "FPG", name: "Fasting plasma glucose", value: Math.round(clamp(baselineGlucose + 5, 110, 260)) } });
+      const startMetforminProb = 0.88 + Math.min(0.08, ((ctx.get("preventiveAdherence") ?? 0.2) - 0.3) * 0.4);
+      const startMetformin = ctx.rngUniform() < Math.min(0.96, Math.max(0.72, startMetforminProb));
+      if (!p.medsOn["Metformin"] && (p.attributes.EGFR as number) > 30 && startMetformin) {
+        ctx.emit({ type: "medication", payload: { drug: "Metformin", dose: "500 mg twice daily" } });
+        p.medsOn["Metformin"] = 1;
+      }
+      ctx.set("t2dm_next_lab", ctx.now + 0.33);
+      ctx.schedule(0.5, { type: "procedure", payload: { code: "2022F", name: "Dilated retinal exam" } });
+    }
+
+    let a1c = ctx.get("t2dm_a1c") ?? ((p.attributes.HBA1C as number) ?? 5.6);
+    const adherence = ctx.get("t2dm_med_adherence") ?? 0;
+    const riskSignal = this.risk(p, ctx);
+    const baselineTarget = clamp(5.8 + riskSignal * 0.6 + stress * 0.2 - activity * 0.03, 5.6, 7.4);
+    const treatedTarget = clamp(7.2 + (1 - adherence) * 1.4 + stress * 0.35 + (diet < 60 ? 0.5 : 0), 6.6, 9);
+    const target = diagnosed ? treatedTarget : baselineTarget;
+    a1c = clamp(a1c + (target - a1c) * 0.2 + ctx.rngNormal(0, 0.05), diagnosed ? 6 : 5.7, diagnosed ? 9.4 : 7.6);
+    ctx.set("t2dm_a1c", Number(a1c.toFixed(1)));
+
+    if (diagnosed && !p.medsOn["GLP-1 RA"] && a1c > 7.8 && ctx.rngUniform() < 0.1) {
+      ctx.emit({ type: "medication", payload: { drug: "Semaglutide", dose: "0.5 mg weekly" } });
+      p.medsOn["GLP-1 RA"] = 1;
+      ctx.set("t2dm_med_adherence", clamp((ctx.get("t2dm_med_adherence") ?? 0.6) + 0.1, 0.4, 0.95));
+    }
+
+    if (diagnosed && !p.medsOn["ACE Inhibitor"] && ((p.attributes.SYSTOLIC_BP as number) ?? 120) > 135) {
+      ctx.emit({ type: "medication", payload: { drug: "Lisinopril", dose: "10 mg daily" } });
+      p.medsOn["ACE Inhibitor"] = 1;
+      ctx.set("ckd_bp_control", (ctx.get("ckd_bp_control") ?? 0) + 0.4);
+    }
+
+    const nextLabDue = ctx.get("t2dm_next_lab") ?? (ctx.now + 0.75);
+    if (ctx.now >= nextLabDue - 1e-6) {
+      const labA1c = clamp(a1c + ctx.rngNormal(0, 0.1), 5.2, 9.5);
+      const glucose = clamp(18 * labA1c + 60 + ctx.rngNormal(0, 10), 85, 250);
+      ctx.emit({ type: "lab", payload: { id: "A1C", name: "Hemoglobin A1c", value: Number(labA1c.toFixed(1)) } });
+      ctx.emit({ type: "lab", payload: { id: "FPG", name: "Fasting plasma glucose", value: Math.round(glucose) } });
+      ctx.set("t2dm_next_lab", ctx.now + (a1c > 7.8 ? 0.33 : 0.5));
+    }
+
+    const nextEye = ctx.get("t2dm_next_eye") ?? (ctx.now + 1.2);
+    if (ctx.now >= nextEye - 1e-6 && diagnosed) {
+      ctx.emit({ type: "procedure", payload: { code: "92250", name: "Annual retinal photography" } });
+      ctx.set("t2dm_next_eye", ctx.now + 1);
+    }
+  },
+  invariants() {
+    return [
+      { name: "Eligible adults", expr: "AGE_YEARS >= 30" },
+      { name: "Metformin requires kidneys", expr: "EGFR > 20" }
+    ];
+  },
+  test() {
+    const patient: any = {
+      attributes: {
+        AGE_YEARS: 55,
+        BMI: 34,
+        FASTING_GLUCOSE: 160,
+        HBA1C: 7.8,
+        FAMILY_HISTORY_DIABETES: true,
+        EGFR: 75,
+        SYSTOLIC_BP: 142
+      },
+      diagnoses: {},
+      medsOn: {},
+      signals: { activityScore: 3, dietScore: 45, stressIndex: 0.4 }
+    };
+    const events: any[] = [];
+    const ctx: any = {
+      now: 40,
+      rngUniform: () => 0.0,
+      rngNormal: () => 0,
+      emit: (e: any) => events.push(e),
+      schedule: () => {},
+      get: (k: string) => patient.signals[k],
+      set: (k: string, v: number) => { patient.signals[k] = v; }
+    };
+    this.init!(patient, ctx);
+    this.step(patient, ctx);
+    return { passed: events.some((e) => e.type === "diagnosis") };
+  }
+};
+
+export default module;

--- a/worlds/clinical_suite/world.json
+++ b/worlds/clinical_suite/world.json
@@ -1,0 +1,39 @@
+{
+  "version": "0.4",
+  "seed": 24680,
+  "model": "hand-authored-clinical-suite",
+  "categories": [
+    {
+      "name": "Demographics",
+      "description": "Demographic context, socioeconomic status, and family history",
+      "targetCount": 10,
+      "durabilityMix": { "intrinsic": 0.6, "semi_durable": 0.4, "stateful": 0 }
+    },
+    {
+      "name": "Lifestyle",
+      "description": "Health behaviors, exposures, and protective factors",
+      "targetCount": 8,
+      "durabilityMix": { "intrinsic": 0.1, "semi_durable": 0.8, "stateful": 0.1 }
+    },
+    {
+      "name": "Clinical Baseline",
+      "description": "Baseline vitals and laboratory markers influenced by lifestyle and disease",
+      "targetCount": 13,
+      "durabilityMix": { "intrinsic": 0.1, "semi_durable": 0.6, "stateful": 0.3 }
+    }
+  ],
+  "attributeModules": [
+    { "id": "DemographicsExtended", "path": "worlds/clinical_suite/attributes/demographics.ts", "category": "Demographics", "declaredCount": 10 },
+    { "id": "LifestyleProfile", "path": "worlds/clinical_suite/attributes/lifestyle.ts", "category": "Lifestyle", "declaredCount": 8 },
+    { "id": "ClinicalBaseline", "path": "worlds/clinical_suite/attributes/clinical_baseline.ts", "category": "Clinical Baseline", "declaredCount": 13 }
+  ],
+  "diseaseModules": [
+    { "id": "Type2DiabetesMellitus", "path": "worlds/clinical_suite/diseases/type2_diabetes.ts", "name": "Type 2 Diabetes Mellitus" },
+    { "id": "CoronaryArteryDisease", "path": "worlds/clinical_suite/diseases/coronary_artery_disease.ts", "name": "Coronary Artery Disease" },
+    { "id": "ChronicObstructivePulmonaryDisease", "path": "worlds/clinical_suite/diseases/copd.ts", "name": "Chronic Obstructive Pulmonary Disease" },
+    { "id": "ChronicKidneyDisease", "path": "worlds/clinical_suite/diseases/ckd.ts", "name": "Chronic Kidney Disease" },
+    { "id": "MajorDepressiveDisorder", "path": "worlds/clinical_suite/diseases/mdd.ts", "name": "Major Depressive Disorder" }
+  ],
+  "attributeCatalogPath": "worlds/clinical_suite/attribute_catalog.json",
+  "acceptance": { "attributesAccepted": 3, "attributesAttempted": 3, "diseasesAccepted": 5, "diseasesAttempted": 5 }
+}


### PR DESCRIPTION
## Summary
- introduce a hand-authored `clinical_suite` world with enriched demographic, lifestyle, and clinical attribute modules plus five detailed disease progressions
- add an `analyze_world.ts` utility to summarize simulated cohorts, including diagnosis rates, labs, medications, and encounter frequency
- tune disease logic to emit realistic diagnoses, labs, therapies, and medication titrations while avoiding repeated diagnoses in long simulations

## Testing
- bun test
- bun src/analyze_world.ts --world worlds/clinical_suite/world.json --n 300

------
https://chatgpt.com/codex/tasks/task_e_68cdc268e7c48329ab53ebefe7819a92