### PR TITLE
feat: introduce functional core simulation kernel

### DIFF
--- a/src/effects.ts
+++ b/src/effects.ts
@@ -1,0 +1,36 @@
+import type { ClinicalEvent } from './events';
+import type { RNG } from './rng';
+import type { Snapshot } from './state';
+import type { Time } from './time';
+
+export interface HazardExplanation {
+  scale: 'additive' | 'log-linear';
+  rate: number;
+  terms: Array<{ label: string; value: number }>;
+}
+
+export type Hazard = ((s: Snapshot, t: Time, rng: RNG) => number) & {
+  explain?: (s: Snapshot, t: Time) => HazardExplanation;
+};
+
+export type HazardModifier = (lambda: number, snapshot: Snapshot, t: Time) => number;
+
+export function applyModifiers(base: Hazard, mods: HazardModifier[], snapshot: Snapshot, t: Time, rng: RNG) {
+  const baseRate = base(snapshot, t, rng);
+  const final = mods.reduce((acc, mod) => mod(acc, snapshot, t), baseRate);
+  return { baseRate, finalRate: final };
+}
+
+export type Effect =
+  | { type: 'emit'; event: ClinicalEvent }
+  | { type: 'setAttr'; key: string; value: unknown }
+  | { type: 'setDisease'; disease: string; state: string }
+  | { type: 'modifyHazard'; process: string; modifierId: string; apply: HazardModifier; until?: Time }
+  | { type: 'schedule'; at: Time; thunk: (ctx: Ctx) => Effect[] };
+
+export interface Ctx {
+  readonly now: Time;
+  readonly pid: string;
+  snapshot(): Snapshot;
+  rng(ns?: string): RNG;
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,38 @@
+import type { Time } from './time';
+
+export type EventKind =
+  | 'EncounterScheduled'
+  | 'EncounterStarted'
+  | 'EncounterFinished'
+  | 'ObservationOrdered'
+  | 'SpecimenCollected'
+  | 'ObservationResulted'
+  | 'MedicationStarted'
+  | 'MedicationStopped'
+  | 'ProcedurePerformed'
+  | 'ConditionOnset'
+  | 'ConditionResolved'
+  | 'Death';
+
+export interface BaseEvent {
+  id: string;
+  pid: string;
+  t: Time;
+  kind: EventKind;
+  relatesTo?: string;
+  meta?: Record<string, unknown>;
+}
+
+export type ClinicalEvent =
+  | (BaseEvent & { kind: 'EncounterScheduled'; meta: { type: 'PCP' | 'ED' | 'Cardio' | 'Endo' } })
+  | (BaseEvent & { kind: 'EncounterStarted'; meta: { type: 'PCP' | 'ED' | 'Cardio' | 'Endo' } })
+  | (BaseEvent & { kind: 'EncounterFinished'; meta: { type: 'PCP' | 'ED' | 'Cardio' | 'Endo' } })
+  | (BaseEvent & { kind: 'ObservationOrdered'; meta: { loinc: string; reason?: string } })
+  | (BaseEvent & { kind: 'ObservationResulted'; meta: { loinc: string; value: number; unit: string } })
+  | (BaseEvent & { kind: 'SpecimenCollected'; meta: { loinc: string } })
+  | (BaseEvent & { kind: 'MedicationStarted'; meta: { rxNorm: string; dose: string } })
+  | (BaseEvent & { kind: 'MedicationStopped'; meta: { rxNorm: string } })
+  | (BaseEvent & { kind: 'ProcedurePerformed'; meta: { code: string } })
+  | (BaseEvent & { kind: 'ConditionOnset'; meta: { icd10: string; label: string } })
+  | (BaseEvent & { kind: 'ConditionResolved'; meta: { icd10: string; label: string } })
+  | (BaseEvent & { kind: 'Death'; meta?: Record<string, unknown> });

--- a/src/fhir.ts
+++ b/src/fhir.ts
@@ -4,29 +4,30 @@ export function toFHIRLite(patient: any) {
     id: patient.id,
     birthDate: `${patient.birthYear}-01-01`
   };
-  const observations = patient.events
-    .filter((e:any)=>e.type==="lab")
-    .map((e:any, idx:number)=>({
+  const events = Array.isArray(patient.events) ? patient.events : [];
+  const observations = events
+    .filter((e: any) => e.kind === 'ObservationResulted')
+    .map((e: any, idx: number) => ({
       resourceType: "Observation",
       id: `${patient.id}-obs-${idx}`,
       status: "final",
-      code: { text: e.payload.name },
-      valueQuantity: { value: e.payload.value, unit: e.payload.unit },
+      code: { text: e.meta?.loinc ?? "" },
+      valueQuantity: { value: e.meta?.value, unit: e.meta?.unit ?? "" },
       effectiveDateTime: isoAtOffset(patient.birthYear, e.t)
     }));
-  const conditions = patient.events
-    .filter((e:any)=>e.type==="diagnosis")
-    .map((e:any, idx:number)=>({
+  const conditions = events
+    .filter((e: any) => e.kind === 'ConditionOnset')
+    .map((e: any, idx: number) => ({
       resourceType: "Condition",
       id: `${patient.id}-cond-${idx}`,
-      code: { text: e.payload.name },
+      code: { text: e.meta?.label ?? e.meta?.icd10 ?? "" },
       onsetDateTime: isoAtOffset(patient.birthYear, e.t)
     }));
   return { patient: patientR, observations, conditions };
 }
-function isoAtOffset(birthYear: number, tYears: number) {
+function isoAtOffset(birthYear: number, tDays: number) {
   const base = new Date(Date.UTC(birthYear, 0, 1));
-  const days = Math.round(tYears * 365.25);
+  const days = Math.round(Number.isFinite(tDays) ? tDays : 0);
   base.setUTCDate(base.getUTCDate() + days);
   return base.toISOString().slice(0, 10);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,9 +57,12 @@ async function handleSimulate(options: CLIOptions) {
   const worldPath = typeof options.world === "string" ? options.world : "out/world/world.json";
   const n = Number(options.n ?? 100);
   const outPath = typeof options.out === "string" ? options.out : undefined;
+  const explain = options.explain === true || options.explain === "true";
+  const horizon = options.horizonYears ?? options.horizon;
+  const horizonYears = horizon != null ? Number(horizon) : undefined;
   const data = await readFile(worldPath, "utf-8");
   const world = JSON.parse(data) as WorldFile;
-  const results = await runSimulation({ n, world });
+  const results = await runSimulation({ n, world, explain, horizonYears });
   const summary = { patients: results.length };
   if (outPath) {
     await mkdir(dirname(outPath), { recursive: true });

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -1,0 +1,413 @@
+import type { ClinicalEvent } from './events';
+import type { Effect, HazardExplanation } from './effects';
+import type { Machine, Transition, Watcher } from './machine';
+import type { Snapshot } from './state';
+import type { Time } from './time';
+import { RNG } from './rng';
+import type { HazardModifier } from './effects';
+import type { Ctx } from './effects';
+
+interface KernelOptions {
+  pid: string;
+  machines: ReadonlyArray<Machine<any>>;
+  initialSnapshot: Snapshot;
+  rng: RNG;
+  start: Time;
+  horizon: Time;
+  explain?: boolean;
+  logger?: (msg: string) => void;
+}
+
+interface TransitionDetail {
+  baseRate: number;
+  finalRate: number;
+  explanation?: HazardExplanation;
+  modifiers: Array<{ id: string; after: number }>;
+}
+
+type ScheduledItem =
+  | { kind: 'transition'; time: Time; machineId: string; transitionIndex: number; version: number; detail: TransitionDetail }
+  | { kind: 'thunk'; time: Time; thunk: (ctx: Ctx) => Effect[] };
+
+class MinQueue<T extends { time: Time }> {
+  private readonly data: Array<{ time: Time; seq: number; item: T }> = [];
+  private seq = 0;
+
+  push(item: T) {
+    const entry = { time: item.time, seq: this.seq++, item };
+    let lo = 0;
+    let hi = this.data.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      const cmp = this.data[mid].time - entry.time || this.data[mid].seq - entry.seq;
+      if (cmp <= 0) lo = mid + 1;
+      else hi = mid;
+    }
+    this.data.splice(lo, 0, entry);
+  }
+
+  pop(): T | undefined {
+    const entry = this.data.shift();
+    return entry?.item;
+  }
+
+  get length() {
+    return this.data.length;
+  }
+}
+
+class KernelCtx implements Ctx {
+  private rngStreams = new Map<string, RNG>();
+
+  constructor(private readonly state: KernelState) {}
+
+  get now(): Time {
+    return this.state.now;
+  }
+
+  get pid(): string {
+    return this.state.pid;
+  }
+
+  snapshot(): Snapshot {
+    return this.state.snapshot();
+  }
+
+  rng(ns = 'default'): RNG {
+    if (!this.rngStreams.has(ns)) {
+      this.rngStreams.set(ns, this.state.baseRng.child(`${ns}:${this.state.streamSeed++}`));
+    }
+    return this.rngStreams.get(ns)!;
+  }
+}
+
+interface ModifierEntry {
+  apply: HazardModifier;
+  token: number;
+}
+
+interface MachineRuntime {
+  state: string;
+  version: number;
+}
+
+class KernelState {
+  readonly pid: string;
+  now: Time;
+  readonly baseRng: RNG;
+  readonly horizon: Time;
+  readonly logger?: (msg: string) => void;
+  readonly explain: boolean;
+
+  private attrs: Record<string, unknown>;
+  private readonly ageBase: number;
+  private diseases: Record<string, string>;
+  private readonly machines: Map<string, Machine<any>>;
+  private readonly runtimes: Map<string, MachineRuntime> = new Map();
+  private readonly modifiers: Map<string, Map<string, ModifierEntry>> = new Map();
+  private readonly watchers: Watcher[];
+  private readonly pq = new MinQueue<ScheduledItem>();
+  private readonly events: ClinicalEvent[] = [];
+  private modifierToken = 1;
+  streamSeed = 1;
+
+  constructor(opts: KernelOptions) {
+    this.pid = opts.pid;
+    this.now = opts.start;
+    this.horizon = opts.horizon;
+    this.baseRng = opts.rng;
+    this.logger = opts.logger;
+    this.explain = !!opts.explain;
+
+    this.attrs = { ...opts.initialSnapshot.attrs };
+    this.ageBase = typeof opts.initialSnapshot.attrs.ageYr === 'number' ? (opts.initialSnapshot.attrs.ageYr as number) : 40;
+    (this.attrs as any).ageYr = this.ageBase;
+    (this.attrs as any).AGE_YEARS = this.ageBase;
+    this.diseases = { ...opts.initialSnapshot.diseases };
+
+    this.machines = new Map(opts.machines.map((m) => [m.id, m]));
+    this.watchers = opts.machines.flatMap((m) => m.watches ?? []);
+
+    for (const machine of opts.machines) {
+      this.diseases[machine.id] = this.diseases[machine.id] ?? machine.initial;
+      this.runtimes.set(machine.id, { state: this.diseases[machine.id], version: 0 });
+      if (machine.modifiers) {
+        const modCatalog = machine.modifiers();
+        const entries = new Map<string, ModifierEntry>();
+        for (const [id, apply] of Object.entries(modCatalog)) {
+          entries.set(id, { apply, token: this.modifierToken++ });
+        }
+        if (entries.size) this.modifiers.set(machine.id, entries);
+      }
+    }
+  }
+
+  getEvents(): ClinicalEvent[] {
+    return this.events;
+  }
+
+  snapshot(): Snapshot {
+    return {
+      attrs: { ...(this.attrs as any) },
+      diseases: { ...this.diseases }
+    };
+  }
+
+  advanceTo(time: Time) {
+    this.now = time;
+    const age = this.ageBase + time / 365;
+    (this.attrs as any).ageYr = age;
+    (this.attrs as any).AGE_YEARS = age;
+  }
+
+  enqueue(item: ScheduledItem) {
+    this.pq.push(item);
+  }
+
+  nextItem(): ScheduledItem | undefined {
+    return this.pq.pop();
+  }
+
+  queueLength() {
+    return this.pq.length;
+  }
+
+  appendEvent(event: ClinicalEvent) {
+    this.events.push(event);
+  }
+
+  setAttr(key: string, value: unknown) {
+    this.attrs = { ...this.attrs, [key]: value };
+  }
+
+  setDisease(id: string, state: string) {
+    if (this.diseases[id] === state) return;
+    this.diseases = { ...this.diseases, [id]: state };
+    const runtime = this.runtimes.get(id);
+    if (runtime) {
+      runtime.state = state;
+      runtime.version += 1;
+      this.scheduleMachine(id);
+    }
+  }
+
+  addModifier(process: string, modifierId: string, apply: HazardModifier): number {
+    let bucket = this.modifiers.get(process);
+    if (!bucket) {
+      bucket = new Map();
+      this.modifiers.set(process, bucket);
+    }
+    const token = this.modifierToken++;
+    bucket.set(modifierId, { apply, token });
+    this.scheduleMachine(process);
+    return token;
+  }
+
+  removeModifier(process: string, modifierId: string, expectedToken: number) {
+    const bucket = this.modifiers.get(process);
+    if (!bucket) return;
+    const entry = bucket.get(modifierId);
+    if (!entry || entry.token !== expectedToken) return;
+    bucket.delete(modifierId);
+    if (!bucket.size) this.modifiers.delete(process);
+    this.scheduleMachine(process);
+  }
+
+  private scheduleMachine(machineId: string) {
+    const machine = this.machines.get(machineId);
+    const runtime = this.runtimes.get(machineId);
+    if (!machine || !runtime) return;
+    runtime.version += 1;
+    const version = runtime.version;
+    const transitions = machine.transitions.filter((t) => t.from === runtime.state);
+    if (!transitions.length) return;
+
+    const snapshot = this.snapshot();
+    let best: { time: Time; transition: Transition<any>; index: number; detail: TransitionDetail } | null = null;
+    const machineMods = this.modifiers.get(machineId);
+
+    transitions.forEach((transition, index) => {
+      const localRng = this.baseRng.child(`${machineId}:v${version}:t${index}`);
+      const baseRate = transition.hazard(snapshot, this.now, localRng);
+      if (!(baseRate > 0)) return;
+      let lambda = baseRate;
+      const applied: Array<{ id: string; after: number }> = [];
+      if (machineMods) {
+        for (const [id, entry] of machineMods.entries()) {
+          lambda = entry.apply(lambda, snapshot, this.now);
+          if (!(lambda > 0)) {
+            applied.push({ id, after: 0 });
+            lambda = 0;
+            break;
+          }
+          applied.push({ id, after: lambda });
+        }
+      }
+      if (!(lambda > 0)) return;
+      const delta = localRng.expo(lambda);
+      if (!Number.isFinite(delta)) return;
+      const eventTime = this.now + delta;
+      if (!best || eventTime < best.time) {
+        best = {
+          time: eventTime,
+          transition,
+          index,
+          detail: {
+            baseRate,
+            finalRate: lambda,
+            explanation: transition.hazard.explain?.(snapshot, this.now),
+            modifiers: applied
+          }
+        };
+      }
+    });
+
+    if (best) {
+      this.enqueue({
+        kind: 'transition',
+        time: best.time,
+        machineId,
+        transitionIndex: best.index,
+        version,
+        detail: best.detail
+      });
+    }
+  }
+
+  dispatchWatchers(event: ClinicalEvent, ctx: KernelCtx) {
+    for (const watcher of this.watchers) {
+      try {
+        if (watcher.match(event)) {
+          const effects = watcher.react(event, ctx) ?? [];
+          if (effects.length) this.applyEffects(effects, ctx);
+        }
+      } catch (err) {
+        this.logger?.(`watcher ${watcher.id} failed: ${String((err as Error).message ?? err)}`);
+      }
+    }
+  }
+
+  applyEffects(effects: Effect[], ctx: KernelCtx) {
+    const queue: Effect[] = [...effects];
+    while (queue.length) {
+      const effect = queue.shift()!;
+      switch (effect.type) {
+        case 'emit': {
+          this.appendEvent(effect.event);
+          this.dispatchWatchers(effect.event, ctx);
+          break;
+        }
+        case 'setAttr': {
+          this.setAttr(effect.key, effect.value);
+          break;
+        }
+        case 'setDisease': {
+          this.setDisease(effect.disease, effect.state);
+          break;
+        }
+        case 'modifyHazard': {
+          const token = this.addModifier(effect.process, effect.modifierId, effect.apply);
+          if (effect.until != null && Number.isFinite(effect.until)) {
+            this.enqueue({
+              kind: 'thunk',
+              time: effect.until,
+              thunk: (tctx) => {
+                this.removeModifier(effect.process, effect.modifierId, token);
+                return [];
+              }
+            });
+          }
+          break;
+        }
+        case 'schedule': {
+          const at = Math.max(effect.at, this.now);
+          this.enqueue({ kind: 'thunk', time: at, thunk: effect.thunk });
+          break;
+        }
+      }
+    }
+  }
+
+  run(): { events: ClinicalEvent[]; snapshot: Snapshot } {
+    for (const machineId of this.machines.keys()) {
+      this.scheduleMachine(machineId);
+    }
+
+    const ctx = new KernelCtx(this);
+
+    while (this.queueLength()) {
+      const item = this.nextItem();
+      if (!item) break;
+      if (item.time > this.horizon) break;
+      this.advanceTo(item.time);
+
+      if (item.kind === 'transition') {
+        const runtime = this.runtimes.get(item.machineId);
+        if (!runtime || item.version !== runtime.version) {
+          continue;
+        }
+        const machine = this.machines.get(item.machineId);
+        if (!machine) continue;
+        const transition = machine.transitions[item.transitionIndex];
+        if (!transition || transition.from !== runtime.state) continue;
+
+        runtime.state = transition.to;
+        runtime.version += 1;
+        this.diseases = { ...this.diseases, [machine.id]: transition.to };
+
+        if (this.explain) this.printTransitionExplain(machine.id, transition, item.detail);
+
+        if (transition.onFire) {
+          try {
+            const effects = transition.onFire(ctx) ?? [];
+            if (effects.length) this.applyEffects(effects, ctx);
+          } catch (err) {
+            this.logger?.(`transition ${machine.id}:${transition.from}->${transition.to} failed: ${String((err as Error).message ?? err)}`);
+          }
+        }
+
+        this.scheduleMachine(machine.id);
+      } else {
+        try {
+          const effects = item.thunk(ctx) ?? [];
+          if (effects.length) this.applyEffects(effects, ctx);
+        } catch (err) {
+          this.logger?.(`thunk execution failed: ${String((err as Error).message ?? err)}`);
+        }
+      }
+    }
+
+    return { events: this.getEvents(), snapshot: this.snapshot() };
+  }
+
+  private printTransitionExplain(machineId: string, transition: Transition<any>, detail: TransitionDetail) {
+    const rate = detail.finalRate;
+    const base = detail.baseRate;
+    const header = `${this.pid} :: ${machineId} ${transition.from}→${transition.to} @ t=${this.now.toFixed(2)}d λ=${rate.toExponential(3)}`;
+    if (this.logger) this.logger(header);
+    else console.log(header);
+    if (detail.explanation) {
+      const prefix = detail.explanation.scale === 'log-linear' ? 'log-rate' : 'rate';
+      for (const term of detail.explanation.terms) {
+        const line = `  ${prefix} +${term.label}: ${term.value.toFixed(4)}`;
+        if (this.logger) this.logger(line);
+        else console.log(line);
+      }
+      const line = `  => base λ=${base.toExponential(3)}`;
+      if (this.logger) this.logger(line);
+      else console.log(line);
+    }
+    if (detail.modifiers.length) {
+      for (const mod of detail.modifiers) {
+        const line = `  modifier ${mod.id} ⇒ λ=${mod.after.toExponential(3)}`;
+        if (this.logger) this.logger(line);
+        else console.log(line);
+      }
+    }
+  }
+}
+
+export function runKernel(opts: KernelOptions) {
+  const state = new KernelState(opts);
+  return state.run();
+}

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -1,0 +1,24 @@
+import type { ClinicalEvent } from './events';
+import type { Ctx, Effect, Hazard, HazardModifier } from './effects';
+
+export interface Transition<S extends string> {
+  from: S;
+  to: S;
+  hazard: Hazard;
+  onFire?: (ctx: Ctx) => Effect[];
+}
+
+export type Watcher = {
+  id: string;
+  match: (event: ClinicalEvent) => boolean;
+  react: (event: ClinicalEvent, ctx: Ctx) => Effect[];
+};
+
+export interface Machine<S extends string> {
+  id: string;
+  states: readonly S[];
+  initial: S;
+  transitions: readonly Transition<S>[];
+  watches?: ReadonlyArray<Watcher>;
+  modifiers?: () => Record<string, HazardModifier>;
+}

--- a/src/modules/diabetes.ts
+++ b/src/modules/diabetes.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from 'node:crypto';
+
+import type { Machine } from '../machine';
+import type { Hazard } from '../effects';
+import { orderLab } from './labs';
+
+type DState = 'SUSC' | 'T2DM' | 'MANAGED';
+
+export function Diabetes(): Machine<DState> {
+  const onset: Hazard = Object.assign(
+    (snapshot) => {
+      const intercept = -7.0;
+      const ageTerm = 0.05 * snapshot.attrs.ageYr;
+      const bmiTerm = 0.08 * (snapshot.attrs.bmi - 25);
+      const sexTerm = snapshot.attrs.sex === 'M' ? 0.2 : 0;
+      const smokeTerm = snapshot.attrs.smoker ? 0.15 : 0;
+      const logRate = intercept + ageTerm + bmiTerm + sexTerm + smokeTerm;
+      return Math.max(1e-6, Math.exp(logRate) / 365);
+    },
+    {
+      explain(snapshot: Parameters<Hazard>[0]) {
+        const intercept = -7.0;
+        const ageTerm = 0.05 * snapshot.attrs.ageYr;
+        const bmiTerm = 0.08 * (snapshot.attrs.bmi - 25);
+        const sexTerm = snapshot.attrs.sex === 'M' ? 0.2 : 0;
+        const smokeTerm = snapshot.attrs.smoker ? 0.15 : 0;
+        const logRate = intercept + ageTerm + bmiTerm + sexTerm + smokeTerm;
+        return {
+          scale: 'log-linear' as const,
+          rate: Math.max(1e-6, Math.exp(logRate) / 365),
+          terms: [
+            { label: 'intercept', value: intercept },
+            { label: 'age', value: ageTerm },
+            { label: 'BMI', value: bmiTerm },
+            { label: 'sex', value: sexTerm },
+            { label: 'smoking', value: smokeTerm }
+          ]
+        };
+      }
+    }
+  );
+
+  const control: Hazard = Object.assign(
+    () => 0.6 / 365,
+    {
+      explain() {
+        return {
+          scale: 'additive' as const,
+          rate: 0.6 / 365,
+          terms: [{ label: 'baseline', value: 0.6 / 365 }]
+        };
+      }
+    }
+  );
+
+  return {
+    id: 't2dm',
+    states: ['SUSC', 'T2DM', 'MANAGED'] as const,
+    initial: 'SUSC',
+    transitions: [
+      {
+        from: 'SUSC',
+        to: 'T2DM',
+        hazard: onset,
+        onFire: (ctx) => [
+          {
+            type: 'emit',
+            event: {
+              id: randomUUID(),
+              pid: ctx.pid,
+              t: ctx.now,
+              kind: 'ConditionOnset',
+              meta: { icd10: 'E11.9', label: 'Type 2 diabetes' }
+            }
+          }
+        ]
+      },
+      {
+        from: 'T2DM',
+        to: 'MANAGED',
+        hazard: control,
+        onFire: (ctx) => [
+          {
+            type: 'emit',
+            event: {
+              id: randomUUID(),
+              pid: ctx.pid,
+              t: ctx.now,
+              kind: 'MedicationStarted',
+              meta: { rxNorm: 'Metformin', dose: '500 mg BID' }
+            }
+          }
+        ]
+      }
+    ],
+    watches: [
+      {
+        id: 'order-a1c-at-visit',
+        match: (event) => event.kind === 'EncounterFinished' && event.meta?.type === 'PCP',
+        react: (_event, ctx) => {
+          const snapshot = ctx.snapshot();
+          const suspect = snapshot.attrs.bmi >= 30 || (typeof snapshot.attrs.a1c === 'number' && (snapshot.attrs.a1c as number) > 6.3);
+          if (snapshot.diseases['t2dm'] !== 'SUSC' || suspect) {
+            return orderLab('4548-4', 'diabetes screening')(ctx);
+          }
+          return [];
+        }
+      },
+      {
+        id: 'diagnose-on-high-a1c',
+        match: (event) => event.kind === 'ObservationResulted' && event.meta?.loinc === '4548-4',
+        react: (event, ctx) => {
+          const value = typeof event.meta?.value === 'number' ? (event.meta.value as number) : NaN;
+          if (value >= 6.5 && ctx.snapshot().diseases['t2dm'] === 'SUSC') {
+            return [
+              { type: 'setDisease', disease: 't2dm', state: 'T2DM' },
+              {
+                type: 'emit',
+                event: {
+                  id: randomUUID(),
+                  pid: ctx.pid,
+                  t: event.t,
+                  kind: 'ConditionOnset',
+                  relatesTo: event.id,
+                  meta: { icd10: 'E11.9', label: 'Type 2 diabetes (lab-confirmed)' }
+                }
+              }
+            ];
+          }
+          return [];
+        }
+      }
+    ]
+  } satisfies Machine<DState>;
+}

--- a/src/modules/encounters.ts
+++ b/src/modules/encounters.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from 'node:crypto';
+
+import type { ClinicalEvent } from '../events';
+import type { Machine } from '../machine';
+import type { Hazard } from '../effects';
+
+export function Encounters(): Machine<'IDLE'> {
+  const cadence: Hazard = Object.assign(
+    (snapshot, _t, _rng) => {
+      const hasChronic = ['t2dm'].some((k) => {
+        const state = snapshot.diseases[k];
+        return state && state !== 'SUSC';
+      });
+      const base = 2 / 365;
+      const chronic = hasChronic ? 1 / 365 : 0;
+      const ageBoost = snapshot.attrs.ageYr > 65 ? 0.5 / 365 : 0;
+      return base + chronic + ageBoost;
+    },
+    {
+      explain(snapshot: Parameters<Hazard>[0]) {
+        const hasChronic = ['t2dm'].some((k) => {
+          const state = snapshot.diseases[k];
+          return state && state !== 'SUSC';
+        });
+        const base = 2 / 365;
+        const chronic = hasChronic ? 1 / 365 : 0;
+        const ageBoost = snapshot.attrs.ageYr > 65 ? 0.5 / 365 : 0;
+        return {
+          scale: 'additive' as const,
+          rate: base + chronic + ageBoost,
+          terms: [
+            { label: 'baseline', value: base },
+            { label: 'chronic disease boost', value: chronic },
+            { label: 'age boost', value: ageBoost }
+          ]
+        };
+      }
+    }
+  );
+
+  return {
+    id: 'encounters',
+    states: ['IDLE'] as const,
+    initial: 'IDLE',
+    transitions: [
+      {
+        from: 'IDLE',
+        to: 'IDLE',
+        hazard: cadence,
+        onFire: (ctx) => {
+          const start: ClinicalEvent = {
+            id: randomUUID(),
+            pid: ctx.pid,
+            t: ctx.now,
+            kind: 'EncounterStarted',
+            meta: { type: 'PCP' }
+          };
+          const duration = Math.max(0.02, ctx.rng('encounter-duration').normal(0.05, 0.02));
+          const finishAt = ctx.now + duration;
+          return [
+            { type: 'emit', event: start },
+            {
+              type: 'schedule',
+              at: finishAt,
+              thunk: (thunkCtx) => {
+                const finish: ClinicalEvent = {
+                  id: randomUUID(),
+                  pid: thunkCtx.pid,
+                  t: finishAt,
+                  kind: 'EncounterFinished',
+                  meta: { type: 'PCP' },
+                  relatesTo: start.id
+                };
+                return [{ type: 'emit', event: finish }];
+              }
+            }
+          ];
+        }
+      }
+    ]
+  } satisfies Machine<'IDLE'>;
+}

--- a/src/modules/labs.ts
+++ b/src/modules/labs.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from 'node:crypto';
+
+import type { ClinicalEvent } from '../events';
+import type { Ctx, Effect } from '../effects';
+
+export function orderLab(loinc: string, reason?: string) {
+  return (ctx: Ctx): Effect[] => {
+    const order: ClinicalEvent = {
+      id: randomUUID(),
+      pid: ctx.pid,
+      t: ctx.now,
+      kind: 'ObservationOrdered',
+      meta: { loinc, reason }
+    };
+    const collectAt = ctx.now + Math.max(0.1, ctx.rng('lab-collect').expo(2));
+    const resultAt = collectAt + Math.max(0.2, ctx.rng('lab-result').expo(1));
+    return [
+      { type: 'emit', event: order },
+      {
+        type: 'schedule',
+        at: collectAt,
+        thunk: (collectCtx) => {
+          const specimen: ClinicalEvent = {
+            id: randomUUID(),
+            pid: collectCtx.pid,
+            t: collectAt,
+            kind: 'SpecimenCollected',
+            meta: { loinc },
+            relatesTo: order.id
+          };
+          return [{ type: 'emit', event: specimen }];
+        }
+      },
+      {
+        type: 'schedule',
+        at: resultAt,
+        thunk: (resultCtx) => {
+          const value = (() => {
+            if (loinc === '4548-4') {
+              const base = typeof resultCtx.snapshot().attrs.a1c === 'number' ? (resultCtx.snapshot().attrs.a1c as number) : 5.3;
+              return Math.max(4.5, resultCtx.rng('lab-value').normal(base, 0.3));
+            }
+            return resultCtx.rng('lab-value').normal(0, 1);
+          })();
+          const result: ClinicalEvent = {
+            id: randomUUID(),
+            pid: resultCtx.pid,
+            t: resultAt,
+            kind: 'ObservationResulted',
+            meta: { loinc, value, unit: loinc === '4548-4' ? '%' : '' },
+            relatesTo: order.id
+          };
+          return [
+            { type: 'emit', event: result },
+            { type: 'setAttr', key: 'a1c', value }
+          ];
+        }
+      }
+    ];
+  };
+}

--- a/src/rng.ts
+++ b/src/rng.ts
@@ -1,0 +1,58 @@
+const TAU = 0x9e3779b9;
+
+function mix(seed: number, value: number): number {
+  let x = (seed ^ value) >>> 0;
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+  return x ^ (x >>> 16);
+}
+
+function hashString(str: string, seed: number): number {
+  let h = seed >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(h ^ str.charCodeAt(i), TAU);
+  }
+  return mix(h, str.length);
+}
+
+export class RNG {
+  private state: number;
+
+  constructor(seed: number) {
+    if (!Number.isFinite(seed)) seed = 0;
+    this.state = seed >>> 0 || 1;
+  }
+
+  private next(): number {
+    let x = this.state >>> 0;
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    this.state = x >>> 0;
+    return this.state / 0xffffffff;
+  }
+
+  float(): number {
+    const u = this.next();
+    return u === 1 ? 0.9999999995 : u;
+  }
+
+  normal(mu = 0, sigma = 1): number {
+    const u = this.float() || 1e-12;
+    const v = this.float() || 1e-12;
+    const mag = Math.sqrt(-2 * Math.log(u));
+    const angle = 2 * Math.PI * v;
+    return mu + sigma * mag * Math.cos(angle);
+  }
+
+  expo(rate: number): number {
+    if (!(rate > 0)) return Number.POSITIVE_INFINITY;
+    const u = this.float() || 1e-12;
+    return -Math.log(1 - u) / rate;
+  }
+
+  child(namespace: string): RNG {
+    const seed = mix(this.state, hashString(namespace, this.state ^ TAU));
+    return new RNG(seed);
+  }
+}

--- a/src/sim.ts
+++ b/src/sim.ts
@@ -1,196 +1,95 @@
-import { mkdir } from "node:fs/promises";
-import { resolve } from "node:path";
+import { mkdir } from 'node:fs/promises';
 
-import { WorldFile, PatientSnapshot, SimContext, Event, AttrValue, AttrLimits } from "./contracts";
-
-class RNG {
-  private state: number;
-  constructor(seed=42){ this.state = seed>>>0; }
-  next(){ let x=this.state; x^=x<<13; x^=x>>>17; x^=x<<5; this.state=x>>>0; return this.state/0xffffffff; }
-  uniform(a=0,b=1){ return a + (b-a)*this.next(); }
-  normal(mean=0, sd=1){ const u=this.next()||1e-9, v=this.next()||1e-9;
-    const z=Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v); return mean+sd*z; }
-}
-class PQ<T>{ data:{t:number;item:T}[]=[]; push(t:number,item:T){const r={t,item}; let lo=0,hi=this.data.length;
-  while(lo<hi){ const mid=(lo+hi)>>>1; if(this.data[mid].t<=t) lo=mid+1; else hi=mid; } this.data.splice(lo,0,r);} 
-  pop(){ const entry = this.data.shift(); return entry ? entry.item : undefined; } get length(){return this.data.length;} }
-
-type PendingEv = { t: number; e: Omit<Event, "t"> };
-type DiseaseRuntime = { id: string; mod: any };
-
-function clampVal(v: any, lim?: AttrLimits): any {
-  if (typeof v !== "number" || !lim) return v;
-  if (Number.isNaN(v) || !Number.isFinite(v)) return 0;
-  if (lim.min != null && v < lim.min) return lim.min;
-  if (lim.max != null && v > lim.max) return lim.max;
-  return v;
-}
+import type { WorldFile } from './contracts';
+import { runKernel } from './kernel';
+import { Diabetes } from './modules/diabetes';
+import { Encounters } from './modules/encounters';
+import { RNG } from './rng';
+import type { ClinicalEvent } from './events';
+import type { Snapshot } from './state';
 
 export type SimulationOptions = {
   n: number;
   world: WorldFile;
+  horizonYears?: number;
+  explain?: boolean;
   llmRuntime?: boolean;
 };
 
-export async function runSimulation(opts: SimulationOptions) {
-  const rng = new RNG(opts.world.seed);
-  const out: any[] = [];
+export type SimulationPatient = {
+  id: string;
+  birthYear: number;
+  attrs: Record<string, unknown>;
+  diseases: Record<string, string>;
+  events: ClinicalEvent[];
+};
 
-  // Limits
-  let limits: Record<string, AttrLimits> = {};
-  if (opts.world.attributeCatalogPath) {
-    try {
-      const cat = await Bun.file(opts.world.attributeCatalogPath).json() as { catalog: Array<{ key: string; limits?: AttrLimits }>};
-      for (const c of cat.catalog) if (c.limits) limits[c.key] = c.limits;
-    } catch {}
+export async function runSimulation(opts: SimulationOptions): Promise<SimulationPatient[]> {
+  const seed = opts.world.seed ?? 42;
+  const horizonYears = opts.horizonYears ?? 5;
+  const horizonDays = horizonYears * 365;
+
+  const patients: SimulationPatient[] = [];
+  for (let i = 0; i < opts.n; i++) {
+    const rng = new RNG((seed + i * 7919) >>> 0);
+    const pid = `P${String(i + 1).padStart(4, '0')}`;
+    const birthYear = 1940 + Math.floor(rng.float() * 60);
+    const age = 18 + rng.float() * 60;
+    const sex = rng.float() < 0.5 ? 'F' : 'M';
+    const bmi = Math.max(16, Math.min(45, rng.normal(27, 4)));
+    const smoker = rng.float() < 0.25;
+    const baselineA1c = Math.max(4.8, rng.normal(5.3 + (bmi - 25) * 0.05, 0.4));
+
+    const attrs: Record<string, unknown> = {
+      ageYr: age,
+      AGE_YEARS: age,
+      AGE_YEARS_BASELINE: age,
+      sex,
+      SEX_AT_BIRTH: sex,
+      bmi,
+      BMI: bmi,
+      smoker,
+      SMOKER: smoker,
+      a1c: baselineA1c
+    };
+
+    const snapshot: Snapshot = { attrs: attrs as any, diseases: {} };
+    const result = runKernel({
+      pid,
+      machines: [Encounters(), Diabetes()],
+      initialSnapshot: snapshot,
+      rng,
+      start: 0,
+      horizon: horizonDays,
+      explain: opts.explain,
+      logger: opts.explain ? (msg) => console.log(msg) : undefined
+    });
+
+    const patient: SimulationPatient = {
+      id: pid,
+      birthYear,
+      attrs: { ...result.snapshot.attrs } as Record<string, unknown>,
+      diseases: { ...result.snapshot.diseases },
+      events: result.events
+    };
+    patients.push(patient);
   }
 
-  // Load modules
-  const attrMods = [];
-  for (const am of opts.world.attributeModules) {
-    const mod = (await import("file://" + resolve(am.path))).default;
-    attrMods.push(mod);
-  }
-  const diseaseMods: DiseaseRuntime[] = [];
-  for (const dm of opts.world.diseaseModules) {
-    const mod = (await import("file://" + resolve(dm.path))).default;
-    diseaseMods.push({ id: dm.id, mod });
-  }
+  const totalEvents = patients.reduce((sum, p) => sum + p.events.length, 0);
+  const deathFraction =
+    patients.filter((p) => p.events.some((e) => e.kind === 'Death')).length / Math.max(1, patients.length);
+  const conditionEvents = patients.reduce(
+    (sum, p) => sum + p.events.filter((e) => e.kind === 'ConditionOnset').length,
+    0
+  );
+  const summary = {
+    patients: patients.length,
+    avgEventsPerPatient: totalEvents / Math.max(1, patients.length),
+    conditionOnsets: conditionEvents,
+    deathFraction
+  };
+  await mkdir('out/sim', { recursive: true });
+  await Bun.write('out/sim/summary.json', JSON.stringify(summary, null, 2));
 
-  for (let i=0;i<opts.n;i++){
-    const pid = "P"+String(i+1);
-    const birthYear = 1940 + Math.floor(rng.uniform()*60);
-    const prng = new RNG((opts.world.seed + i*7919)>>>0);
-    const signals: Record<string, number> = {};
-    const attributes: Record<string, AttrValue> = {};
-    let sexAtBirth: "M"|"F"|"U" = "U";
-
-    // Generate attributes
-    for (const m of attrMods) {
-      const g = m.generate(prng.next()*1e9|0, birthYear);
-      for (const [k, spec] of Object.entries<any>(g.attributes)) {
-        const lim = spec.limits;
-        if (lim) limits[k] = limits[k] ?? lim;
-        attributes[k] = clampVal(spec.value, limits[k]);
-      }
-      if (g.signals) Object.assign(signals, g.signals);
-      if (g.sexAtBirth && sexAtBirth==="U") sexAtBirth = g.sexAtBirth;
-    }
-    const startAge = typeof attributes["AGE_YEARS"] === "number" ? (attributes["AGE_YEARS"] as number) : 18;
-    attributes["AGE_YEARS"] = startAge;
-    if (!("SEX_AT_BIRTH" in attributes)) attributes["SEX_AT_BIRTH"] = sexAtBirth;
-
-    const patient: PatientSnapshot = {
-      id: pid, birthYear, ageYears: startAge,
-      sexAtBirth: (attributes["SEX_AT_BIRTH"] as any) ?? "U",
-      attributes, signals, diagnoses: {}, medsOn: {},
-      rngSeed: prng.next()*1e9|0
-    };
-
-    const events: Event[] = [];
-    const Q = new PQ<PendingEv>();
-    const y2t = (y:number)=>y;
-    const ctx: SimContext = {
-      now: startAge, y2t,
-      rngUniform: ()=>prng.uniform(),
-      rngNormal: (m=0,s=1)=>prng.normal(m,s),
-      emit: (e:Event)=>{
-        const ev = { ...e, t: ctx.now } as Event;
-        events.push(ev);
-        if (ev.type === "diagnosis") patient.diagnoses[ev.payload.code] = 1;
-        if (ev.type === "medication") patient.medsOn[ev.payload.drug] = 1;
-      },
-      schedule: (delayYears:number, e:Omit<Event, "t">)=>{
-        const delay = Math.max(0, delayYears);
-        const target = ctx.now + delay;
-        Q.push(target, { t: target, e });
-      },
-      get: (k:string)=>patient.signals[k],
-      set: (k:string,v:number)=>{ patient.signals[k]=v; },
-      attr: (id:string)=>patient.attributes[id],
-      setAttr: (id:string,v:any)=>{ patient.attributes[id]= clampVal(v, limits[id]); },
-      log: (_:string)=>{}
-    };
-
-    // Routine encounters & death
-    const maxAge = 115;
-    const scheduleEncounterSeries = (beginAge: number, meanMonths: number) => {
-      const horizon = Math.min(maxAge, startAge + 35);
-      let next = Math.max(beginAge, startAge + 0.25);
-      while (next < horizon) {
-        Q.push(next, { t: next, e: { type: "encounter", payload: { kind: "PCP" } } });
-        const jitter = (prng.uniform() - 0.5) * 0.25; // +/- 3 months jitter
-        const stepYears = Math.max(0.5, meanMonths / 12 + jitter);
-        next += stepYears;
-      }
-    };
-    const youngCadence = startAge < 40 ? 14 : 18;
-    const seniorCadence = startAge >= 65 ? 10 : youngCadence;
-    scheduleEncounterSeries(startAge + prng.uniform(), seniorCadence);
-
-    const sampleDeathAge = () => {
-      const skipChance = Math.min(0.5, Math.max(0.15, 0.36 - Math.max(0, startAge - 35) * 0.0035));
-      if (prng.uniform() < skipChance) return Number.POSITIVE_INFINITY;
-      const mean = 88;
-      const scale = 10;
-      for (let attempt = 0; attempt < 8; attempt++) {
-        const u = prng.uniform();
-        if (u <= 0 || u >= 1) continue;
-        const draw = mean + scale * Math.log(u / (1 - u));
-        if (draw > startAge + 0.75 && draw < maxAge) return draw;
-      }
-      return Number.POSITIVE_INFINITY;
-    };
-    const deathAge = sampleDeathAge();
-    if (Number.isFinite(deathAge)) {
-      Q.push(deathAge, { t: deathAge, e: { type: "death", payload: {} } });
-    }
-
-    // Init diseases
-    for (const D of diseaseMods) if (typeof D.mod.init === "function") D.mod.init(patient, ctx);
-
-    // Eligibility cache
-    let eCache: Record<string, boolean> = {};
-    const recomputeEligibility = () => {
-      eCache = {}; for (const D of diseaseMods) {
-        try { eCache[D.id] = !!D.mod.eligible(patient); } catch { eCache[D.id] = false; }
-      }
-    };
-    recomputeEligibility();
-
-    // Sim loop
-    let lastT = startAge;
-    while (Q.length){
-      const { t, e } = Q.pop()!;
-      const months = Math.max(0, Math.floor((t - lastT)*12));
-      for (let m=0;m<months;m++){
-        patient.ageYears = lastT + (m+1)/12;
-        patient.attributes["AGE_YEARS"] = patient.ageYears;
-        ctx.now = patient.ageYears;
-        for (const mod of attrMods) if (typeof mod.update === "function") { try { mod.update(patient, ctx, 1/12); } catch {} }
-        recomputeEligibility();
-        for (const D of diseaseMods) if (eCache[D.id]) { try { D.mod.step(patient, ctx); } catch {} }
-      }
-      lastT = t; patient.ageYears = t; patient.attributes["AGE_YEARS"] = patient.ageYears; ctx.now = t;
-      patient.signals["core_lastEventAge"] = t;
-      if (e.type === "encounter") patient.signals["core_lastEncounterAge"] = t;
-      if (e.type === "death") patient.signals["core_deathAge"] = t;
-      events.push({ ...e, t });
-      if (e.type === "death") break;
-      if (e.type === "encounter") for (const D of diseaseMods) if (eCache[D.id]) { try { D.mod.step(patient, ctx); } catch {} }
-    }
-
-    for (const ev of events) if (ev.type === "diagnosis") patient.diagnoses[ev.payload.code] = 1;
-    out.push({ id: pid, birthYear, attrs: patient.attributes, signals: patient.signals, events });
-  }
-
-  const totalEvents = out.reduce((a:any,p:any)=>a+p.events.length,0);
-  const avgEvents = totalEvents / Math.max(1,out.length);
-  const deathFrac = out.filter((p:any)=>p.events.some((e:any)=>e.type==="death")).length / Math.max(1,out.length);
-  const dxCount = out.reduce((a:any,p:any)=>a+p.events.filter((e:any)=>e.type==="diagnosis").length,0);
-  const metrics = { patients: out.length, avgEventsPerPatient: avgEvents, diagnosisEvents: dxCount, deathFraction: deathFrac };
-  await mkdir("out/sim", { recursive: true });
-  await Bun.write("out/sim/summary.json", JSON.stringify(metrics, null, 2));
-
-  return out;
+  return patients;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,20 @@
+export type Sex = 'F' | 'M';
+
+export interface Attributes {
+  readonly ageYr: number;
+  readonly sex: Sex;
+  readonly bmi: number;
+  readonly smoker: boolean;
+  readonly sbp?: number;
+  readonly a1c?: number;
+  readonly [key: string]: unknown;
+}
+
+export interface DiseaseStateMap {
+  readonly [diseaseId: string]: string;
+}
+
+export interface Snapshot {
+  readonly attrs: Attributes;
+  readonly diseases: DiseaseStateMap;
+}

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,0 +1,1 @@
+export type Time = number; // measured in days from simulation epoch

--- a/src/world_builder.ts
+++ b/src/world_builder.ts
@@ -185,10 +185,10 @@ async function validateWorldQuick(world: WorldFile, worldDir: string) {
     const { runSimulation } = await import("./sim");
     const sample = await runSimulation({ n: 50, world, llmRuntime: false });
     const eventCounts = sample.map((p: any) => p.events.length);
-    const avgEvents = eventCounts.reduce((a: number, b: number) => a + b, 0) / eventCounts.length;
-    const deathFrac = sample.filter((p: any) => p.events.some((e: any) => e.type === "death")).length / sample.length;
+    const avgEvents = eventCounts.reduce((a: number, b: number) => a + b, 0) / Math.max(1, eventCounts.length);
+    const deathFrac = sample.filter((p: any) => p.events.some((e: any) => e.kind === 'Death')).length / Math.max(1, sample.length);
     const dxCount = sample.reduce(
-      (a: number, p: any) => a + p.events.filter((e: any) => e.type === "diagnosis").length,
+      (a: number, p: any) => a + p.events.filter((e: any) => e.kind === 'ConditionOnset').length,
       0
     );
     const metrics = { avgEventsPerPatient: avgEvents, deathFraction: deathFrac, diagnosisEvents: dxCount };


### PR DESCRIPTION
## Summary
- replace the legacy imperative simulator with a functional-core kernel that drives machines and watchers
- add reusable definitions for events, effects, hazards, RNG utilities, and concrete encounter/diabetes modules
- update analytics, FHIR export, and world validation tooling to consume the new clinical event stream

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68ce022b63e083298f67797472e9a071